### PR TITLE
Add Fortran signatures to docs

### DIFF
--- a/docs/source/bmi.control_funcs.rst
+++ b/docs/source/bmi.control_funcs.rst
@@ -26,6 +26,12 @@ Initialization
     /* C++ */
     void Initialize (const char *config_file);
 
+.. code-block:: fortran
+
+   ! Fortran (>=2003)
+   integer function initialize(self, config_file)
+
+
 
 The `initialize` function accepts a string argument that gives the
 name (and path) of its "main input file", or *configuration file*.
@@ -61,6 +67,12 @@ Time stepping
     void Update(void);
     void UpdateUntil(double then);
 
+.. code-block:: fortran
+
+   ! Fortran (>=2003)
+   integer function update(self)
+   integer function update_until(self, then)
+
 The `update` function advances the model by a single timestep. This
 is the model's own internal timestep (as returned by the BMI
 `get_time_step` function) - not the timestep of a controlling application.
@@ -95,6 +107,11 @@ Finalization
 
     /* C++ */
     void Finalize(void);
+
+.. code-block:: fortran
+
+   ! Fortran (>=2003)
+   integer function finalize(self)
 
 The `finalize` function should perform all tasks that take place
 after exiting the model's time loop.  This typically includes

--- a/docs/source/bmi.control_funcs.rst
+++ b/docs/source/bmi.control_funcs.rst
@@ -29,10 +29,9 @@ Initialization
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   function initialize(self, config_file) result (bmi_status)
+   integer function initialize(self, config_file)
      class (*), intent(out) :: self
      character (len=*), intent(in) :: config_file
-     integer :: bmi_status
 
 
 The `initialize` function accepts a string argument that gives the
@@ -72,14 +71,11 @@ Time stepping
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   function update(self) result (bmi_status)
+   integer function update(self)
      class (*), intent(inout) :: self
-     integer :: bmi_status
-
-   function update_until(self, then) result (bmi_status)
+   integer function update_until(self, then)
      class (*), intent(inout) :: self
      double precision, intent(in) :: then
-     integer :: bmi_status
 
 
 The `update` function advances the model by a single timestep. This
@@ -120,9 +116,8 @@ Finalization
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   function finalize(self) result (bmi_status)
+   integer function finalize(self)
      class (*), intent(inout) :: self
-     integer :: bmi_status
 
 The `finalize` function should perform all tasks that take place
 after exiting the model's time loop.  This typically includes

--- a/docs/source/bmi.control_funcs.rst
+++ b/docs/source/bmi.control_funcs.rst
@@ -29,8 +29,8 @@ Initialization
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function initialize(self, config_file)
-     class (*), intent(out) :: self
+   integer function initialize(this, config_file)
+     class (*), intent(out) :: this
      character (len=*), intent(in) :: config_file
 
 
@@ -71,10 +71,10 @@ Time stepping
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function update(self)
-     class (*), intent(inout) :: self
-   integer function update_until(self, then)
-     class (*), intent(inout) :: self
+   integer function update(this)
+     class (*), intent(inout) :: this
+   integer function update_until(this, then)
+     class (*), intent(inout) :: this
      double precision, intent(in) :: then
 
 
@@ -116,8 +116,8 @@ Finalization
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function finalize(self)
-     class (*), intent(inout) :: self
+   integer function finalize(this)
+     class (*), intent(inout) :: this
 
 The `finalize` function should perform all tasks that take place
 after exiting the model's time loop.  This typically includes

--- a/docs/source/bmi.control_funcs.rst
+++ b/docs/source/bmi.control_funcs.rst
@@ -29,8 +29,10 @@ Initialization
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function initialize(self, config_file)
-
+   function initialize(self, config_file) result (bmi_status)
+     class (*), intent(out) :: self
+     character (len=*), intent(in) :: config_file
+     integer :: bmi_status
 
 
 The `initialize` function accepts a string argument that gives the
@@ -70,8 +72,15 @@ Time stepping
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function update(self)
-   integer function update_until(self, then)
+   function update(self) result (bmi_status)
+     class (*), intent(inout) :: self
+     integer :: bmi_status
+
+   function update_until(self, then) result (bmi_status)
+     class (*), intent(inout) :: self
+     double precision, intent(in) :: then
+     integer :: bmi_status
+
 
 The `update` function advances the model by a single timestep. This
 is the model's own internal timestep (as returned by the BMI
@@ -111,7 +120,9 @@ Finalization
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function finalize(self)
+   function finalize(self) result (bmi_status)
+     class (*), intent(inout) :: self
+     integer :: bmi_status
 
 The `finalize` function should perform all tasks that take place
 after exiting the model's time loop.  This typically includes

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -116,8 +116,9 @@ are:
 * des (Timestep size varies in both space and time.  See below.)
 * none (State variables do not vary in time.)
 
-Note that DES ([http://en.wikipedia.org/wiki/Discrete_event_simulation
-Discrete Event Simulation]) models allow each grid cell to have its
+Note that `Discrete Event Simulation
+<http://en.wikipedia.org/wiki/Discrete_event_simulation>`_
+(DES) models allow each grid cell to have its
 own, adaptive time step.
 
 The "grid_type" attribute can be used by a framework to automatically

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -33,13 +33,13 @@ Input and output variable names
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function get_input_var_name_count(self, count)
-   integer function get_output_var_name_count(self, count)
-     class (*), intent(in) :: self
+   integer function get_input_var_name_count(this, count)
+   integer function get_output_var_name_count(this, count)
+     class (*), intent(in) :: this
      integer, intent(out) :: count
-   integer function get_input_var_names(self, names)
-   integer function get_output_var_names(self, names)
-     class (*), intent(in) :: self
+   integer function get_input_var_names(this, names)
+   integer function get_output_var_names(this, names)
+     class (*), intent(in) :: this
      character (len=*), pointer, intent(out) :: names(:)
 
 
@@ -70,8 +70,8 @@ Component name
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   intger function get_component_name(self, name)
-     class (*), intent(in) :: self
+   intger function get_component_name(this, name)
+     class (*), intent(in) :: this
      character (len=*), pointer, intent(out) :: name
 
 

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -33,10 +33,17 @@ Input and output variable names
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function get_input_var_name_count(self, count)
-   integer function get_output_var_name_count(self, count)
-   integer function get_input_var_names(self, names)
-   integer function get_output_var_names(self, names)
+   function get_input_var_name_count(self, count) result (bmi_status)
+   function get_output_var_name_count(self, count) result (bmi_status)
+     class (*), intent(in) :: self
+     integer, intent(out) :: count
+     integer :: bmi_status
+
+   function get_input_var_names(self, names) result (bmi_status)
+   function get_output_var_names(self, names) result (bmi_status)
+     class (*), intent(in) :: self
+     character (len=*), pointer, intent(out) :: names(:)
+     integer :: bmi_status
 
 
 `get_input_var_names` returns a string array of the model's
@@ -66,7 +73,10 @@ Component name
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   integer function get_component_name(self, name)
+   function get_component_name(self, name) result (bmi_status)
+     class (*), intent(in) :: self
+     character (len=*), pointer, intent(out) :: name
+     integer :: bmi_status
 
 
 Return the name of the model as a string. We don't impose any

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -33,17 +33,14 @@ Input and output variable names
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   function get_input_var_name_count(self, count) result (bmi_status)
-   function get_output_var_name_count(self, count) result (bmi_status)
+   integer function get_input_var_name_count(self, count)
+   integer function get_output_var_name_count(self, count)
      class (*), intent(in) :: self
      integer, intent(out) :: count
-     integer :: bmi_status
-
-   function get_input_var_names(self, names) result (bmi_status)
-   function get_output_var_names(self, names) result (bmi_status)
+   integer function get_input_var_names(self, names)
+   integer function get_output_var_names(self, names)
      class (*), intent(in) :: self
      character (len=*), pointer, intent(out) :: names(:)
-     integer :: bmi_status
 
 
 `get_input_var_names` returns a string array of the model's
@@ -73,10 +70,9 @@ Component name
 .. code-block:: fortran
 
    ! Fortran (>=2003)
-   function get_component_name(self, name) result (bmi_status)
+   intger function get_component_name(self, name)
      class (*), intent(in) :: self
      character (len=*), pointer, intent(out) :: name
-     integer :: bmi_status
 
 
 Return the name of the model as a string. We don't impose any

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -30,6 +30,14 @@ Input and output variable names
   void GetInputVarNames(char * const * const names);
   void GetOutputVarNames(char * const * const names);
 
+.. code-block:: fortran
+
+   ! Fortran (>=2003)
+   integer function get_input_var_name_count(self, count)
+   integer function get_output_var_name_count(self, count)
+   integer function get_input_var_names(self, names)
+   integer function get_output_var_names(self, names)
+
 
 `get_input_var_names` returns a string array of the model's
 *input variable* names as, preferably, CSDMS Standard Names.
@@ -54,6 +62,11 @@ Component name
 
   /* C++ */
   void GetComponentName(char * const name);
+
+.. code-block:: fortran
+
+   ! Fortran (>=2003)
+   integer function get_component_name(self, name)
 
 
 Return the name of the model as a string. We don't impose any

--- a/docs/source/bmi.time_funcs.rst
+++ b/docs/source/bmi.time_funcs.rst
@@ -20,6 +20,8 @@ Time units
 
 Return the units of time as reported by the model's BMI (through
 `get_current_time`_, `get_end_time`_, etc.).
+CSDMS recommends using time unit conventions from Unidata's
+`UDUNITS <https://www.unidata.ucar.edu/software/udunits/>`_ package.
 
 Time step
 ---------


### PR DESCRIPTION
Fortran doesn't have function prototypes, but I added signatures of the Fortran BMI functions to the sections where prototypes in SIDL, C, and C++ are shown.