### PR TITLE
Minor updates

### DIFF
--- a/bmi.sidl
+++ b/bmi.sidl
@@ -1,4 +1,4 @@
-package csdms version 0.0 {
+package csdms version 1.0 {
   interface bmi {
     int initialize(in string config_file);	            	
     int update(in double time_interval);	            	

--- a/bmi.sidl
+++ b/bmi.sidl
@@ -8,7 +8,7 @@
       https://csdms.colorado.edu/wiki/BMI_Description
 
 */
-package csdms version 1.0 {
+package csdms version 1.1 {
   interface bmi {
     int initialize(in string config_file);	            	
     int update(in double time_interval);	            	
@@ -31,6 +31,7 @@ package csdms version 1.0 {
     int get_var_nbytes(in string name, out int nbytes);
     int get_var_itemsize(in string name, out int size);
     int get_var_grid(in string name, out int grid);
+    int get_var_location(in string name, out string location);
 
     // Grid information
     int get_grid_type(in int grid, out string type);

--- a/bmi.sidl
+++ b/bmi.sidl
@@ -1,3 +1,13 @@
+/*
+  The CSDMS Basic Model Interface
+
+  This Scientific Interface Definition Language (SIDL) file describes
+  the Basic Model Interface (BMI) in a human-readable, language- and
+  platform-independent manner. For more information on the BMI, see:
+
+      https://csdms.colorado.edu/wiki/BMI_Description
+
+*/
 package csdms version 1.0 {
   interface bmi {
     int initialize(in string config_file);	            	

--- a/docs/source/bmi.grid_funcs.rst
+++ b/docs/source/bmi.grid_funcs.rst
@@ -105,7 +105,7 @@ Uniform rectilinear
 .. code-block:: java
 
     array<float> get_grid_origin(in int id)
-    array<int> get_grid_spacing(in int id)
+    array<float> get_grid_spacing(in int id)
 
 .. image:: images/mesh_uniform_rectilinear.png
    :scale: 20 %


### PR DESCRIPTION
This PR contains three minor changes:

1. Adds a version number to the BMI expressed in the SIDL file
1. Adds a header to the SIDL file
1. Fixes the output type of the `get_grid_spacing` function in the docs