### PR TITLE
improvement: make python Bmi an abstract base class.

### DIFF
--- a/bmi.py
+++ b/bmi.py
@@ -1,9 +1,11 @@
+from abc import ABC, abstractmethod
 from typing import Tuple
 
 import numpy as np
 
 
-class Bmi:
+class Bmi(ABC):
+    @abstractmethod
     def initialize(self, config_file: str) -> None:
         """Perform startup tasks for the model.
 
@@ -15,7 +17,7 @@ class Bmi:
         Parameters
         ----------
         config_file : str, optional
-          The path to the model configuration file.
+            The path to the model configuration file.
 
         Notes
         -----
@@ -27,6 +29,7 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def update(self) -> None:
         """Advance model state by one time step.
 
@@ -38,6 +41,7 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def finalize(self) -> None:
         """Perform tear-down tasks for the model.
 
@@ -47,16 +51,18 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_component_name(self) -> str:
         """Name of the component.
 
         Returns
         -------
         str
-          The name of the component.
+            The name of the component.
         """
         ...
 
+    @abstractmethod
     def get_input_var_names(self) -> Tuple[str]:
         """List of a model's input variables.
 
@@ -66,7 +72,7 @@ class Bmi:
         Returns
         -------
         list of str
-          The input variables for the model.
+            The input variables for the model.
 
         Notes
         -----
@@ -79,6 +85,7 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_output_var_names(self) -> Tuple[str]:
         """List of a model's output variables.
 
@@ -88,17 +95,18 @@ class Bmi:
         Returns
         -------
         list of str
-          The output variables for the model.
+            The output variables for the model.
         """
         ...
 
+    @abstractmethod
     def get_var_grid(self, name: str) -> int:
         """Get grid identifier for the given variable.
 
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
@@ -107,21 +115,23 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_var_type(self, name: str) -> str:
         """Get data type of the given variable.
 
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
         str
-          The Python variable type; e.g., ``str``, ``int``, ``float``.
+            The Python variable type; e.g., ``str``, ``int``, ``float``.
         """
         ...
 
+    @abstractmethod
     def get_var_units(self, name: str) -> str:
         """Get units of the given variable.
 
@@ -136,81 +146,102 @@ class Bmi:
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
         str
-          The variable units.
+            The variable units.
 
         Notes
         -----
         CSDMS uses the `UDUNITS`_ standard from Unidata.
 
         .. _UDUNITS: http://www.unidata.ucar.edu/software/udunits
-
         """
         ...
 
+    @abstractmethod
     def get_var_itemsize(self, name: str) -> int:
         """Get memory use for each array element in bytes.
 
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
         int
-          Item size in bytes.
+            Item size in bytes.
         """
         ...
 
+    @abstractmethod
     def get_var_nbytes(self, name: str) -> int:
         """Get size, in bytes, of the given variable.
 
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
         int
-          The size of the variable, counted in bytes.
+            The size of the variable, counted in bytes.
         """
         ...
 
+    @abstractmethod
     def get_var_location(self, name: str) -> str:
         """Get the grid element type that the a given variable is defined on.
 
-        Grids can be composed of *nodes*, *edges*, and *faces*. *nodes* are
-        point that have coordinates
+        The grid topology can be composed of *nodes*, *edges*, and *faces*.
+
+        *node*
+            A point that has a coordinate pair or triplet: the most
+            basic element of the topology.
+
+        *edge*
+            A line or curve bounded by two *nodes*.
+
+        *face*
+            A plane or surface enclosed by a set of edges. In a 2D
+            horizontal application one may consider the word “polygon”,
+            but in the hierarchy of elements the word “face” is most common.
 
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
         str
-          The grid location on which the variable is defined. Must be one of
-          `"node"`, `"edge"`, or `"face"`.
+            The grid location on which the variable is defined. Must be one of
+            `"node"`, `"edge"`, or `"face"`.
+
+        Notes
+        -----
+        CSDMS uses the `ugrid conventions`_ to define unstructured grids.
+
+        .. _UGRID: http://ugrid-conventions.github.io/ugrid-conventions
         """
         ...
 
+    @abstractmethod
     def get_current_time(self) -> float:
         """Current time of the model.
 
         Returns
         -------
         float
-          The current model time.
+            The current model time.
         """
         ...
 
+    @abstractmethod
     def get_start_time(self) -> float:
         """Start time of the model.
 
@@ -219,27 +250,29 @@ class Bmi:
         Returns
         -------
         float
-          The model start time.
+            The model start time.
         """
         ...
 
+    @abstractmethod
     def get_end_time(self) -> float:
         """End time of the model.
 
         Returns
         -------
         float
-          The maximum model time.
+            The maximum model time.
         """
         ...
 
+    @abstractmethod
     def get_time_units(self) -> str:
         """Time units of the model.
 
         Returns
         -------
         float
-          The model time unit; e.g., `days` or `s`.
+            The model time unit; e.g., `days` or `s`.
 
         Notes
         -----
@@ -247,6 +280,7 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_time_step(self) -> float:
         """Current time step of the model.
 
@@ -255,10 +289,11 @@ class Bmi:
         Returns
         -------
         float
-          The time step used in model.
+            The time step used in model.
         """
         ...
 
+    @abstractmethod
     def get_value(self, name: str, dest: np.ndarray) -> np.ndarray:
         """Get a copy of values of the given variable.
 
@@ -280,6 +315,7 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_value_ptr(self, name: str) -> np.ndarray:
         """Get a reference to values of the given variable.
 
@@ -290,7 +326,7 @@ class Bmi:
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
 
         Returns
         -------
@@ -299,6 +335,7 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_value_at_indices(
         self, name: str, dest: np.ndarray, inds: np.ndarray
     ) -> np.ndarray:
@@ -307,27 +344,20 @@ class Bmi:
         Parameters
         ----------
         name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
         dest : ndarray
             A numpy array into which to place the values.
         indices : array_like
-          The indices into the variable array.
+            The indices into the variable array.
 
         Returns
         -------
         array_like
             Value of the model variable at the given location.
-
-        Notes
-        -----
-        .. code-block:: c
-
-            /* C */
-            int get_value_at_indices(void * self, const char * var_name,
-                                     void * buffer, int * indices, int len);
         """
         ...
 
+    @abstractmethod
     def set_value(self, name: str, values: np.ndarray) -> None:
         """Specify a new value for a model variable.
 
@@ -339,12 +369,13 @@ class Bmi:
         Parameters
         ----------
         var_name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
         src : array_like
-          The new value for the specified variable.
+            The new value for the specified variable.
         """
         ...
 
+    @abstractmethod
     def set_value_at_indices(
         self, name: str, inds: np.ndarray, src: np.ndarray
     ) -> None:
@@ -353,78 +384,83 @@ class Bmi:
         Parameters
         ----------
         var_name : str
-          An input or output variable name, a CSDMS Standard Name.
+            An input or output variable name, a CSDMS Standard Name.
         indices : array_like
-          The indices into the variable array.
+            The indices into the variable array.
         src : array_like
-          The new value for the specified variable.
+            The new value for the specified variable.
         """
         ...
 
     # Grid information
+    @abstractmethod
     def get_grid_rank(self, grid: int) -> int:
         """Get number of dimensions of the computational grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
 
         Returns
         -------
         int
-          Rank of the grid.
+            Rank of the grid.
         """
         ...
 
+    @abstractmethod
     def get_grid_size(self, grid: int) -> int:
         """Get the total number of elements in the computational grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
 
         Returns
         -------
         int
-          Size of the grid.
+            Size of the grid.
         """
         ...
 
+    @abstractmethod
     def get_grid_type(self, grid: int) -> str:
         """Get the grid type as a string.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
 
         Returns
         -------
         str
-          Type of grid as a string.
+            Type of grid as a string.
         """
         ...
 
     # Uniform rectilinear
+    @abstractmethod
     def get_grid_shape(self, grid: int, shape: np.ndarray) -> np.ndarray:
         """Get dimensions of the computational grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         shape : ndarray of int, shape *(ndim,)*
             A numpy array into which to place the shape of the grid.
 
         Returns
         -------
         ndarray of int
-          The input numpy array that holds the grid's shape.
+            The input numpy array that holds the grid's shape.
         """
         ...
 
+    @abstractmethod
     def get_grid_spacing(self, grid: int, spacing: np.ndarray) -> np.ndarray:
         """Get distance between nodes of the computational grid.
 
@@ -442,13 +478,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_origin(self, grid: int, origin: np.ndarray) -> np.ndarray:
         """Get coordinates for the lower-left corner of the computational grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         origin : ndarray of float, shape *(ndim,)*
             A numpy array to hold the coordinates of the lower-left corner of
             the grid.
@@ -462,13 +499,14 @@ class Bmi:
         ...
 
     # Non-uniform rectilinear, curvilinear
+    @abstractmethod
     def get_grid_x(self, grid: int, x: np.ndarray) -> np.ndarray:
         """Get coordinates of grid nodes in the x direction.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         x : ndarray of float, shape *(nrows,)*
             A numpy array to hold the x-coordinates of the grid node columns.
 
@@ -479,13 +517,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_y(self, grid: int, y: np.ndarray) -> np.ndarray:
         """Get coordinates of grid nodes in the y direction.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         y : ndarray of float, shape *(ncols,)*
             A numpy array to hold the y-coordinates of the grid node rows.
 
@@ -496,13 +535,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_z(self, grid: int, z: np.ndarray) -> np.ndarray:
         """Get coordinates of grid nodes in the z direction.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         z : ndarray of float, shape *(nlayers,)*
             A numpy array to hold the z-coordinates of the grid nodes layers.
 
@@ -513,13 +553,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_node_count(self, grid: int) -> int:
         """Get the number of nodes in the grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
 
         Returns
         -------
@@ -528,13 +569,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_edge_count(self, grid: int) -> int:
         """Get the number of edges in the grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
 
         Returns
         -------
@@ -543,13 +585,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_face_count(self, grid: int) -> int:
         """Get the number of faces in the grid.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
 
         Returns
         -------
@@ -558,13 +601,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_edge_nodes(self, grid: int, edge_nodes: np.ndarray) -> np.ndarray:
         """Get the edge-node connectivity.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         edge_nodes : ndarray of int, shape *(2 x nnodes,)*
             A numpy array to place the edge-node connectivity. For each edge,
             connectivity is given as node at edge tail, followed by node at
@@ -577,13 +621,14 @@ class Bmi:
         """
         ...
 
+    @abstractmethod
     def get_grid_face_nodes(self, grid: int, face_nodes: np.ndarray) -> np.ndarray:
         """Get the face-node connectivity.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         face_nodes : ndarray of int
             A numpy array to place the face-node connectivity. For each face,
             the nodes (listed in a counter-clockwise direction) that form the
@@ -596,13 +641,16 @@ class Bmi:
         """
         ...
 
-    def get_grid_nodes_per_face(self, grid: int, nodes_per_face: np.ndarray) -> np.ndarray:
+    @abstractmethod
+    def get_grid_nodes_per_face(
+        self, grid: int, nodes_per_face: np.ndarray
+    ) -> np.ndarray:
         """Get the number of nodes for each face.
 
         Parameters
         ----------
         grid : int
-          A grid identifier.
+            A grid identifier.
         nodes_per_face : ndarray of int, shape *(nfaces,)*
             A numpy array to place the number of edges per face.
 


### PR DESCRIPTION
This pull request makes the `bmi.Bmi` class an abstract base class. Every method is now an *abstractmethod* and so each must be overridden before any derived classes can be instantiated. Methods that are not applicable to a particular implementation should simply raise a `NotImplementedError`.