### PR TITLE
Add project docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,23 @@
+=======
+Credits
+=======
+
+Project Coordinators
+--------------------
+
+* Eric Hutton <mcflugen@gmail.com>
+* Mark Piper <mark.piper@colorado.edu>
+
+Contributors
+------------
+
+* Richard Barnes
+* Eric Hutton
+* Boyana Norris
+* Scott Peckham
+* Mark Piper
+* Mike Taves
+
+If you have contributed to the BMI package and your name is missing,
+please send an email to the coordinators, or open a pull request
+for this page in the `BMI repository <https://github.com/csdms/bmi>`_.

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,0 +1,25 @@
+Citation
+========
+
+If you use the Basic Model Interface for work/research
+presented in a publication, we ask that you please cite:
+
+Peckham, S.D., Hutton, E.W. and Norris, B., 2013. A component-based approach to integrated modeling in the geosciences: The design of CSDMS. *Computers & Geosciences*, 53, pp.3-12, http://dx.doi.org/10.1016/j.cageo.2012.04.002.
+
+Full article:
+
+http://www.sciencedirect.com/science/article/pii/S0098300412001252
+
+BibTeX entry:
+
+.. code-block::
+
+  @article{peckham2013component,
+    title={A component-based approach to integrated modeling in the geosciences: The design of CSDMS},
+    author={Peckham, Scott D and Hutton, Eric WH and Norris, Boyana},
+    journal={Computers \& Geosciences},
+    volume={53},
+    pages={3--12},
+    year={2013},
+    publisher={Elsevier}
+  }

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at csdms@colorado.edu. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/CODE-OF-CONDUCT.rst
+++ b/CODE-OF-CONDUCT.rst
@@ -1,6 +1,8 @@
-# Contributor Covenant Code of Conduct
+Contributor Covenant Code of Conduct
+====================================
 
-## Our Pledge
+Our Pledge
+----------
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
@@ -9,7 +11,8 @@ size, disability, ethnicity, sex characteristics, gender identity and expression
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
-## Our Standards
+Our Standards
+-------------
 
 Examples of behavior that contributes to creating a positive environment
 include:
@@ -31,7 +34,8 @@ Examples of unacceptable behavior by participants include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+Our Responsibilities
+--------------------
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -43,7 +47,8 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-## Scope
+Scope
+-----
 
 This Code of Conduct applies within all project spaces, and it also applies when
 an individual is representing the project or its community in public spaces.
@@ -52,7 +57,8 @@ project e-mail address, posting via an official social media account, or acting
 as an appointed representative at an online or offline event. Representation of
 a project may be further defined and clarified by project maintainers.
 
-## Enforcement
+Enforcement
+-----------
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at csdms@colorado.edu. All
@@ -65,13 +71,13 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-## Attribution
+Attribution
+-----------
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-
-[homepage]: https://www.contributor-covenant.org
+This Code of Conduct is adapted from the
+`Contributor Covenant <https://www.contributor-covenant.org>`_, version 1.4,
+available at
+`<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>`_.
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
-
+`<https://www.contributor-covenant.org/faq>`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,103 @@
+.. highlight:: shell
+
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+----------------------
+
+Report Bugs
+~~~~~~~~~~~
+
+Report bugs at https://github.com/csdms/bmi/issues.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+~~~~~~~~
+
+Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
+wanted" is open to whoever wants to implement it.
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the GitHub issues for features. Anything tagged with "enhancement"
+and "help wanted" is open to whoever wants to implement it.
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+BMI could always use more documentation, whether as part of the
+official docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+
+The best way to send feedback is to file an issue at
+https://github.com/csdms/bmi/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+Get Started!
+------------
+
+Ready to contribute? Here's how to set up BMI for local development.
+
+1. Fork the BMI repo on GitHub.
+1. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/bmi.git
+
+1. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+1. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+1. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+3. The pull request should work for Python 2.7, 3.6 and 3.7.
+   Make sure that the tests pass for all supported Python versions.
+
+Deploying
+---------
+
+A reminder for the maintainers on how to deploy.
+Make sure all your changes are committed (including an entry in HISTORY.rst).
+Then run::
+
+$ git tag v<major>.<minor>.<patch>
+$ git push
+$ git push --tags

--- a/README.rst
+++ b/README.rst
@@ -51,5 +51,5 @@ The most current development version is always available from our git repository
 http://github.com/csdms/bmi
 
 Please note that this project is released with a
-`Contributor Code of Conduct <./CODE-OF-CONDUCT.md>`_.
+`Contributor Code of Conduct <./CODE-OF-CONDUCT.rst>`_.
 By participating in this project you agree to abide by its terms.

--- a/README.rst
+++ b/README.rst
@@ -40,12 +40,6 @@ framework-specific data structures. BMI therefore introduces no
 dependencies into a model and the model can still be used
 in a *stand-alone* manner.
 
-Scott D. Peckham, Eric W.H. Hutton, Boyana Norris, A component-based approach to integrated modeling in the geosciences: The design of CSDMS, Computers & Geosciences, Volume 53, April 2013, Pages 3-12, ISSN 0098-3004, http://dx.doi.org/10.1016/j.cageo.2012.04.002.
-
-Full article:
-
-http://www.sciencedirect.com/science/article/pii/S0098300412001252
-
 The most current development version is always available from our git repository:
 
 http://github.com/csdms/bmi

--- a/README.rst
+++ b/README.rst
@@ -49,3 +49,7 @@ http://www.sciencedirect.com/science/article/pii/S0098300412001252
 The most current development version is always available from our git repository:
 
 http://github.com/csdms/bmi
+
+Please note that this project is released with a
+`Contributor Code of Conduct <./CODE-OF-CONDUCT.md>`_.
+By participating in this project you agree to abide by its terms.

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 The Basic Model Interface
 =========================
 
-Documentation: https://bmi-spec.readthedocs.io
+Documentation: https://bmi.readthedocs.io
 
 License: MIT
 

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CITATION.rst

--- a/docs/source/conduct.rst
+++ b/docs/source/conduct.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CODE-OF-CONDUCT.rst

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CONTRIBUTING.rst

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -1,0 +1,1 @@
+.. include:: ../../AUTHORS.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@
 
 
 Additional Topics
------------------
+=================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,3 +27,4 @@ Project Information
    :maxdepth: 2
 
    contributing
+   conduct

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,5 +26,6 @@ Project Information
 .. toctree::
    :maxdepth: 1
 
+   citation
    contributing
    conduct

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,3 +19,11 @@ Additional Topics
 
    csdms
    references
+
+Project Information
+===================
+
+.. toctree::
+   :maxdepth: 2
+
+   contributing

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,3 +29,4 @@ Project Information
    citation
    contributing
    conduct
+   credits

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Project Information
 ===================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    contributing
    conduct


### PR DESCRIPTION
This PR adds the following documents to the top level of the project:

* AUTHORS
* CITATION
* CODE-OF-CONDUCT
* CONTRIBUTING

It also references these documents in the documentation.

This fixes #47.