### PR TITLE
Update SIDL file

### DIFF
--- a/bmi.sidl
+++ b/bmi.sidl
@@ -1,4 +1,4 @@
-package csdms version 1.3 {
+package csdms version 1.3b0 {
   interface bmi {
     int initialize(in string config_file);
     int update();

--- a/bmi.sidl
+++ b/bmi.sidl
@@ -1,22 +1,22 @@
-package csdms version 0.0 {
+package csdms version 1.3 {
   interface bmi {
-    int initialize(in string config_file);	            	
-    int update(in double time_interval);	            	
-    int finalize();	            	
-            
+    int initialize(in string config_file);
+    int update();
+    int update_until(in double then);
+    int finalize();
+
     int get_component_name(out string name);
     int get_input_item_count(out int count);
     int get_output_item_count(out int count);
     int get_input_var_names(out array<string, 1> names);
     int get_output_var_names(out array<string, 1> names);
 
-    int get_var_grid(in string name, out int grid_id);
+    int get_var_grid(in string name, out int grid);
     int get_var_type(in string name, out string type);
     int get_var_units(in string name, out string units);
     int get_var_itemsize(in string name, out int size);
     int get_var_nbytes(in string name, out int nbytes);
     int get_var_location(in string name, out string location);
-    int get_var_grid(in string name, out int grid);
 
     int get_current_time(out double time);
     int get_start_time(out double time);

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -2,12 +2,29 @@
 References
 ==========
 
-* The Community Surface Dynamics Modeling System (`CSDMS <https://csdms.colorado.edu>`_)
-* Bmi `documentation <https://csdms.colorado.edu>`_
-* Bmi description and bindings on `GitHub <https://github.com/csdms/bmi>`_
-* Computer & Geosciences article `describing BMI <http://www.sciencedirect.com/science/article/pii/S0098300412001252>`_
+Community Surface Dynamics Modeling System (CSDMS):
 
-  Scott D. Peckham, Eric W.H. Hutton, Boyana Norris, *A component-based
-  approach to integrated modeling in the geosciences: The design of
-  CSDMS*, Computers & Geosciences, Volume 53, April 2013, Pages 3-12,
-  ISSN 0098-3004, http://dx.doi.org/10.1016/j.cageo.2012.04.002.
+  Syvitski, James P; Hutton, Eric; Piper, Mark; Overeem, Irina;
+    Kettner, Albert; Peckham, Scott (2014): "Plug and play component
+    modeling--the CSDMS 2.0 approach", *International Environmental
+    Modelling and Software Society (iEMSs), 7th International Congress
+    on Environmental Modelling and Software* (Ames DP, Quinn N., eds),
+    San Diego, CA,
+    USA. http://www.iemss.org/society/index.php/iemss-2014-proceedings.
+
+Basic Model Interface (BMI):
+
+  Peckham, Scott D; Hutton, Eric WH; Norris, Boyana (2013): "A
+    component-based approach to integrated modeling in the
+    geosciences: The design of CSDMS", *Computers & Geosciences*,
+    **53**: 3-12, ISSN 0098-3004,
+    http://dx.doi.org/10.1016/j.cageo.2012.04.002.
+
+Scientific Interface Definition Language (SIDL):
+
+  Epperly, Thomas GW; Kumfert, Gary; Dahlgren, Tamara; Ebner, Dietmar;
+    Leek, Jim; Prantl, Adrian; Kohn, Scott (2011): "High-performance
+    language interoperability for scientific computing through
+    Babel". *The International Journal of High Performance Computing
+    Applications*. **26** (3): 260–274.
+    http://dx.doi.org/10.1177/1094342011414036

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -2,7 +2,7 @@
 References
 ==========
 
-Community Surface Dynamics Modeling System (CSDMS):
+Community Surface Dynamics Modeling System (CSDMS)
 
   Syvitski, James P; Hutton, Eric; Piper, Mark; Overeem, Irina;
     Kettner, Albert; Peckham, Scott (2014): "Plug and play component
@@ -12,7 +12,7 @@ Community Surface Dynamics Modeling System (CSDMS):
     San Diego, CA,
     USA. http://www.iemss.org/society/index.php/iemss-2014-proceedings.
 
-Basic Model Interface (BMI):
+Basic Model Interface (BMI)
 
   Peckham, Scott D; Hutton, Eric WH; Norris, Boyana (2013): "A
     component-based approach to integrated modeling in the
@@ -20,7 +20,12 @@ Basic Model Interface (BMI):
     **53**: 3-12, ISSN 0098-3004,
     http://dx.doi.org/10.1016/j.cageo.2012.04.002.
 
-Scientific Interface Definition Language (SIDL):
+Scientific Interface Definition Language (SIDL)
+
+  Dahlgren, Tamara; Ebner, Dietmar; Epperly, Thomas; Kumfert, Gary;
+    Leek, James; Prantl, Adrian (): "Babel User's Guide: Part I
+    Foundation: SIDL Basics".
+    https://computing.llnl.gov/projects/babel-high-performance-language-interoperability/docs/users_guide/index008.html (retrieved 2019-10-09).
 
   Epperly, Thomas GW; Kumfert, Gary; Dahlgren, Tamara; Ebner, Dietmar;
     Leek, Jim; Prantl, Adrian; Kohn, Scott (2011): "High-performance


### PR DESCRIPTION
This PR updates the SIDL file (of which all other BMIs are but reflections, kinda like Roger Zelazny's Amber) to the latest BMI specification, matching the [Python BMI](https://github.com/csdms/bmi-python/blob/master/bmipy/bmi.py) recently revised by @mcflugen. The scope of the PR is narrow -- it only makes the SIDL file current, it doesn't augment the file with additional functionality available in SIDL. Additionally, I've set the version at 1.3b0, and added references for SIDL to the BMI documentation.