### PR TITLE
Add notes on variable and time units

### DIFF
--- a/docs/source/bmi.time_funcs.rst
+++ b/docs/source/bmi.time_funcs.rst
@@ -83,13 +83,16 @@ The end time of the  model.
 Get the units of time as reported by the model's BMI (through
 :ref:`get_current_time`, :ref:`get_end_time`, etc.).
 It's recommended to use `time unit conventions`_ from Unidata's
-`UDUNITS`_ package; e.g., `s`, `min`, `h`, `d`.
+`UDUNITS`_ package; e.g., ``"s"``, ``"min"``, ``"h"``, ``"d"``.
 
 **Implementation notes**
 
-* Avoid using `years` as a unit, if possible, since a year is
+* Avoid using ``"years"`` as a unit, if possible, since a year is
   difficult to define precisely. UDUNITS defines a year as 365.2422
   days or 31556926 seconds.
+* Dimensionless quantities should use ``""`` or ``"1"`` as the unit.
+* Models that don't vary with time, or don't have time units should
+  use ``"none"``.
 * In C++ and Python, the argument is omitted and the units are returned
   from the function.
 

--- a/docs/source/bmi.var_funcs.rst
+++ b/docs/source/bmi.var_funcs.rst
@@ -76,13 +76,13 @@ while in Fortran, use `integer`, `real`, and `double precision`.
    int get_var_units(in string name, out string units);
 
 Get the units of the given variable.
-Standard unit names, in lower case, should be used, such as `meters`
-or `seconds`.
-Standard abbreviations, such as `m` for meters, are
+Standard unit names, in lower case, should be used,
+such as ``"meters"`` or ``"seconds"``.
+Standard abbreviations, such as ``"m"`` for meters, are
 also supported. For variables with compound units, each unit name
 is separated by a single space, with exponents other than 1 placed
-immediately after the name, as in `m s-1` for velocity, `W m-2` for
-an energy flux, or `km2` for an area.
+immediately after the name, as in ``"m s-1"`` for velocity,
+``"W m-2"`` for an energy flux, or ``"km2"`` for an area.
 The abbreviations used in the BMI are derived from
 Unidata's `UDUNITS`_ package.
 See, for example, `The Units Database`_ for a
@@ -90,6 +90,8 @@ full description of valid unit names and a list of supported units.
 
 **Implementation notes**
 
+* Dimensionless quantities should use ``""`` or ``"1"`` as the unit.
+* Variables without units should use ``"none"``.
 * In C++ and Python, the *units* argument is omitted and the variable
   units name is returned from the function.
 


### PR DESCRIPTION
This update reflects a discussion in https://github.com/csdms/bmi-tester/pull/22.

Also changed formatting in the docs to use a monospace font and quotes around the units (e.g., `"km"`) to set them off from the text.