### PR TITLE
Autobuild docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Documentation
+
+on:
+    push:
+        paths:
+            - "docs/**"
+            - "AUTHORS.rst"
+            - "CITATION.rst"
+            - "CODE-OF-CONDUCT.rst"
+            - "CONTRIBUTING.rst"
+            - "README.rst"
+    pull_request:
+        paths:
+            - "docs/**"
+            - "AUTHORS.rst"
+            - "CITATION.rst"
+            - "CODE-OF-CONDUCT.rst"
+            - "CONTRIBUTING.rst"
+            - "README.rst"
+
+jobs:
+    build:
+        # We want to run on external PRs, but not on our own internal PRs as they'll be run
+        # by the push to the branch. Without this if check, checks are duplicated since
+        # internal PRs match both the push and pull_request events.
+        if:
+          github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+          github.repository
+    
+        runs-on: ubuntu-latest
+
+        steps:
+          - uses: actions/checkout@v2
+          - uses: actions/setup-python@v2
+
+          - name: Install dependencies
+            run: pip install sphinx
+
+          - name: Build documentation
+            run: make -C docs clean html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ formats:
   - htmlzip
 
 python:
-  version: 3.9
+  version: 3.8
   system_packages: true
 
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: false
+
+formats:
+  - htmlzip
+
+python:
+  version: 3.9
+  system_packages: true
+
+build:
+  image: latest

--- a/docs/source/_templates/localtoc.html
+++ b/docs/source/_templates/localtoc.html
@@ -1,0 +1,2 @@
+<h3><a href="{{ pathto(master_doc) }}">Contents</a></h3>
+{{ toc }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,14 +170,16 @@ html_sidebars = {
     "index": [
         "sidebarintro.html",
         "links.html",
-        "sourcelink.html",
         "searchbox.html",
+        "localtoc.html",
+        "sourcelink.html",
     ],
     "**": [
         "sidebarintro.html",
         "links.html",
-        "sourcelink.html",
         "searchbox.html",
+        "localtoc.html",
+        "sourcelink.html",
     ]
 }
 


### PR DESCRIPTION
This PR sets up a GitHub Actions workflow to build the docs on pushes and PRs, and configures Read the Docs for the same.

Unrelated, I also added a sidebar TOC to aid navigation of the main page of the docs.