### PR TITLE
Add goverance docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,6 @@ Contributors
 * Ben van Werkhoven
 * Martijn Visser
 
-If you have contributed to the BMI package and your name is missing,
+If you have contributed to the BMI project and your name is missing,
 please send an email to the coordinators, or open a pull request
 for this page in the `BMI repository <https://github.com/csdms/bmi>`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,46 +4,133 @@
 Contributing
 ============
 
-Contributions are welcome, and they are greatly appreciated! Every little bit
-helps, and credit will always be given.
+Contributions are welcomed and greatly appreciated!
+BMI is a community-driven open source project, so every little bit helps.
+`Credit`_ will always be given.
 
-You can contribute in many ways:
+This document describes how to contribute to the BMI project.
+It covers the main `BMI repository`_,
+as well as the language specifications and examples
+for supported languages
+listed in `Table 1`_ of the `BMI documentation`_.
 
-Types of Contributions
-----------------------
+--------------
+Making changes
+--------------
 
-Report Bugs
-~~~~~~~~~~~
+The following sections describe the process through which changes to the BMI
+specification, language bindings, language examples, and support tools are made.
 
-Report bugs at https://github.com/csdms/bmi/issues.
+Pull requests
+~~~~~~~~~~~~~
 
-If you are reporting a bug, please include:
+If you'd like to propose a change to the BMI or any of its language
+bindings, examples, or tools, you must submit a pull request (PR) to the
+corresponding GitHub repository. If you have questions regarding a potential
+change, or if you're unsure whether your proposed changes or additions are
+acceptable, we recommend you first submit your question as a GitHub issue in the
+corresponding repository, which can later be turned into a PR.
 
-* Your operating system name and version.
-* Any details about your local setup that might be helpful in troubleshooting.
-* Detailed steps to reproduce the bug.
+When a PR is opened against the BMI or any of its language bindings, examples,
+or tools, it will be tagged either as a *Request for Comment* (RFC) or for
+resolution through *lazy consensus*. The RFC process is intended for major
+changes to the BMI, whereas lazy consensus applies to minor changes such as
+typos or documentation updates.
 
-Fix Bugs
-~~~~~~~~
+Request for Comment (RFC)
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
-wanted" is open to whomever wants to implement it.
+Once a PR has been tagged as an RFC, a review process begins.
+It proceeds in three steps:
 
-Implement Features
-~~~~~~~~~~~~~~~~~~
+1. discussion
+2. summary
+3. resolution
 
-Look through the GitHub issues for features. Anything tagged with "enhancement"
-and "help wanted" is open to whomever wants to implement it.
+Discussion
+..........
 
-Write Documentation
-~~~~~~~~~~~~~~~~~~~
+Reviewers (the other developers and interested community members) will write
+comments on your PR to help you improve its implementation, documentation, and
+style. Every single developer working on the project has their code reviewed,
+and we've come to see it as friendly conversation from which we all learn and
+the overall code quality benefits. Therefore, please don't let the review
+discourage you from contributing: its only aim is to improve the quality of
+project, not to criticize (we are, after all, very grateful for the time you're
+donating!).
 
-BMI could always use more documentation, whether as part of the
-official docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+The author of the PR should try to build consensus and integrate feedback. An
+RFC with broad support will be more likely to be quickly accepted than one
+without comments. If you feel that your PR has been forgotten,
+please feel free to reach out directly to the project team.
 
-Submit Feedback
-~~~~~~~~~~~~~~~
+We expect that most PRs will not be accepted without some modification. You can
+make changes by pushing commits directly to the PR branch and leaving comments
+that explain the modifications.
+
+Summary
+.......
+
+Once all parties have weighed in and there has been adequate discussion, the PR
+moves to a summary period. A team member will move for the discussion
+phase to end and for the summary period to begin, which will end with a
+recommendation for the RPC (merge, close, or, postpone). Team members making
+this motion should use their best judgment that adequate discussion has taken
+place and that the consequences of the proposed change have been adequately
+addressed.
+
+The summary period will typically last about a week, allowing
+stakeholders to have a chance to lodge any final objections before the team
+reaches a final decision.
+
+The intent is for this summary period to be fairly quiet, with most of the
+discussion taking place during the discussion phase. There will likely be times,
+however, where stakeholders might raise serious enough concerns that the PR
+moves back into the discussion phase.
+
+Resolution
+..........
+
+The RFC process concludes with the PR being merged, closed, or postponed.
+
+There must be a *consensus* from project developers and interested community
+members for a PR to be merged. Consensus has a particular meaning when used
+with open source projects; see the `BMI governance document`_ for a definition
+of consensus in this context.
+
+If consensus isn't achieved, the PR will be postponed (the team feels the PR can
+wait until some future time) or closed.
+
+Lazy Consensus
+~~~~~~~~~~~~~~
+
+`Lazy consensus`_, as defined by the Apache Software Foundation, is a
+decision-making policy which assumes general consent if no responses are posted
+within a defined period.
+
+For the BMI project, a PR tagged for resolution through lazy consensus can be
+merged if no comments are posted within one week.
+
+-------------------
+Reporting a problem
+-------------------
+
+Report bugs or other problems by creating a GitHub issue at
+https://github.com/csdms/bmi/issues.
+
+In the issue, be sure to explain the problem and include additional details to
+help maintainers reproduce the problem. Here are some suggestions that will make
+it easier to track down the source of the problem:
+
+* Use a clear and descriptive title for the issue that identifies the problem.
+* Describe, and if possible provide a minimal example that demonstrates, the
+  exact steps that reproduce the problem.
+* Describe the behavior you are seeing after these steps.
+* Describe the behavior you expect to see after these steps.
+
+------------------
+Providing feedback
+------------------
 
 The best way to send feedback is to file an issue at
 https://github.com/csdms/bmi/issues.
@@ -53,52 +140,14 @@ If you are proposing a feature:
 * Explain in detail how it would work.
 * Keep the scope as narrow as possible, to make it easier to implement.
 * Remember that this is a volunteer-driven project, and that contributions
-  are welcome :)
+  are welcome.
 
-Get Started!
-------------
 
-Ready to contribute? Here's how to set up BMI for local development.
+.. Links
 
-1. Fork the BMI repo on GitHub.
-
-2. Clone your fork locally::
-
-    $ git clone git@github.com:your_name_here/bmi.git
-
-3. Create a branch for local development::
-
-    $ git checkout -b name-of-your-bugfix-or-feature
-
-   Now you can make your changes locally.
-
-4. Commit your changes and push your branch to GitHub::
-
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
-
-5. Submit a pull request through the GitHub website.
-
-Pull Request Guidelines
------------------------
-
-Before you submit a pull request, check that it meets these guidelines:
-
-1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.6 and 3.7.
-   Make sure that the tests pass for all supported Python versions.
-
-Deploying
----------
-
-A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed (including an entry in HISTORY.rst).
-Then run::
-
-$ git tag v<major>.<minor>.<patch>
-$ git push
-$ git push --tags
+.. _Credit: https://bmi.readthedocs.io/en/latest/credits.html
+.. _BMI repository: https://github.com/csdms/bmi
+.. _Table 1: https://bmi.readthedocs.io/en/latest/#id43
+.. _BMI documentation: https://bmi.readthedocs.io
+.. _BMI governance document: https://bmi.readthedocs.io/en/latest/governance.html
+.. _Lazy consensus: https://community.apache.org/committers/lazyConsensus.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,7 +55,7 @@ comments on your PR to help you improve its implementation, documentation, and
 style. Every single developer working on the project has their code reviewed,
 and we've come to see it as friendly conversation from which we all learn and
 the overall code quality benefits. Therefore, please don't let the review
-discourage you from contributing: its only aim is to improve the quality of
+discourage you from contributing: its only aim is to improve the quality of the
 project, not to criticize (we are, after all, very grateful for the time you're
 donating!).
 
@@ -74,7 +74,7 @@ Summary
 Once all parties have weighed in and there has been adequate discussion, the PR
 moves to a summary period. A team member will move for the discussion
 phase to end and for the summary period to begin, which will end with a
-recommendation for the RPC (merge, close, or, postpone). Team members making
+recommendation for the RFC (merge, close, or, postpone). Team members making
 this motion should use their best judgment that adequate discussion has taken
 place and that the consequences of the proposed change have been adequately
 addressed.
@@ -109,7 +109,7 @@ decision-making policy which assumes general consent if no responses are posted
 within a defined period.
 
 For the BMI project, a PR tagged for resolution through lazy consensus can be
-merged if no comments are posted within one week.
+merged if no comments are posted within about a week.
 
 -------------------
 Reporting a problem

--- a/docs/source/_templates/links.html
+++ b/docs/source/_templates/links.html
@@ -5,7 +5,7 @@
   <li><a href="./glossary.html">Glossary</a></li>
   <li><a href="https://github.com/csdms/bmi/">BMI @ GitHub</a></li>
   <li><a href="https://github.com/csdms/bmi/issues">Issue Tracker</a></li>
+  <li><a href="./index.html#project-information">Project Information</a></li>
   <li><a href="https://csdms.colorado.edu/wiki/Workbench">CSDMS Workbench</a></li>
   <li><a href="https://csdms.colorado.edu">CSDMS Homepage</a></li>
 </ul>
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'bmi'
-copyright = u'2020, Community Surface Dynamics Modeling System'
+copyright = u'2021, Community Surface Dynamics Modeling System'
 author = u'Community Surface Dynamics Modeling System'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/council.rst
+++ b/docs/source/council.rst
@@ -1,0 +1,2 @@
+Steering Council
+================

--- a/docs/source/governance.rst
+++ b/docs/source/governance.rst
@@ -1,0 +1,26 @@
+The Basic Model Interface (BMI): governance and decision-making
+===============================================================
+
+The purpose of this document is to formalize the governance process
+used for the Basic Model Interface (BMI)
+in both ordinary and extraordinary situations,
+and to clarify how decisions are made
+and how the various elements of our community interact,
+including the relationship between open source collaborative development
+and work that may be funded by for-profit or non-profit entities.
+
+Summary
+-------
+
+The Basic Model Interface (BMI) is a community-owned and community-run project.
+To the maximum extent possible, decisions about project direction
+are made by community consensus
+(but note that "consensus" here has a somewhat technical meaning
+that might not match everyone's expectations--see below).
+Some members of the community additionally contribute
+by serving on the Steering Council (see below),
+where they are responsible
+for facilitating the establishment of community consensus,
+for stewarding project resources,
+and--in extreme cases--for making project decisions
+if the normal community-based process breaks down.

--- a/docs/source/governance.rst
+++ b/docs/source/governance.rst
@@ -1,26 +1,347 @@
 The Basic Model Interface (BMI): governance and decision-making
 ===============================================================
 
-The purpose of this document is to formalize the governance process
-used for the Basic Model Interface (BMI)
-in both ordinary and extraordinary situations,
-and to clarify how decisions are made
-and how the various elements of our community interact,
-including the relationship between open source collaborative development
-and work that may be funded by for-profit or non-profit entities.
+The purpose of this document is to formalize the governance process used for the
+Basic Model Interface (BMI) in both ordinary and extraordinary situations, and
+to clarify how decisions are made and how the various elements of our community
+interact, including the relationship between open source collaborative
+development and work that may be funded by for-profit or non-profit entities.
 
 Summary
 -------
 
 The Basic Model Interface (BMI) is a community-owned and community-run project.
-To the maximum extent possible, decisions about project direction
-are made by community consensus
-(but note that "consensus" here has a somewhat technical meaning
-that might not match everyone's expectations--see below).
-Some members of the community additionally contribute
-by serving on the Steering Council (see below),
-where they are responsible
-for facilitating the establishment of community consensus,
-for stewarding project resources,
-and--in extreme cases--for making project decisions
-if the normal community-based process breaks down.
+To the maximum extent possible, decisions about project direction are made by
+community consensus (but note that "consensus" here has a somewhat technical
+meaning that might not match everyone's expectations--see below). Some members
+of the community additionally contribute by serving on the Steering Council (see
+below), where they are responsible for facilitating the establishment of
+community consensus, for stewarding project resources, and--in extreme
+cases--for making project decisions if the normal community-based process breaks
+down.
+
+The Project
+-----------
+
+BMI is an open source software project (hereafter, the Project) affiliated with
+the NSF-funded `Community Surface Dynamics Modeling System`_ (CSDMS). The goal
+of the Project is to develop an open source software interface standard for
+querying and controlling models. The Project also includes tools, documentation,
+and examples to support and promote this standard. The software developed by the
+Project is released under the MIT open source license, developed openly, and
+hosted on public GitHub repositories under the csdms and other GitHub
+organization. Proposed changes to the Project must follow the `CONTRIBUTING`_
+document in the Project's main GitHub repository.
+
+The Project is developed by a team of distributed developers, called
+Contributors. Contributors are individuals who have contributed code,
+documentation, designs, or other work to the Project. Anyone can be a
+Contributor. Contributors can be affiliated with any legal entity or none.
+Contributors participate in the project by submitting, reviewing, and discussing
+GitHub pull requests and issues and participating in open and public Project
+discussions on GitHub and other channels. The foundation of Project
+participation is openness and transparency.
+
+The Project Community consists of all Contributors and Users of the Project.
+Contributors work on behalf of and are responsible to the larger Project
+Community. We strive to keep the barrier between Contributors and Users as low
+as possible.
+
+Governance
+----------
+
+This section describes the governance and leadership model of the Project. The
+foundations of Project governance are:
+
+* Openness & Transparency
+* Active Contribution
+* Institutional Neutrality
+
+Consensus-based decision making by the community
+................................................
+
+Normally, decisions on the Project will be made by consensus of all interested
+Contributors. The primary goal of this approach is to ensure that the people who
+are most affected by and involved in any given change can contribute their
+knowledge in the confidence that their voices will be heard, because thoughtful
+review from a broad community is the best mechanism we know of for creating
+high-quality software.
+
+The mechanism we use to accomplish this goal may be unfamiliar for those who are
+not experienced with the cultural norms around free/open-source software
+development. We provide a summary here, and highly recommend that all
+Contributors additionally read the chapter `Social and Political
+Infrastructure`_ of Karl Fogel's *Producing Open Source Software*, and in
+particular the section on `Consensus-based Democracy`_, for a more detailed
+discussion.
+
+In this context, consensus does not require:
+
+* that we wait to solicit everyone's opinion on every change,
+* that we ever hold a vote on anything, or
+* that everyone is happy or agrees with every decision.
+
+For us, what consensus means is that we entrust everyone with the right to veto
+any change if they feel it necessary. While this may sound like a recipe for
+obstruction, this is not what happens. Instead, we find that most people take
+this responsibility seriously, and only invoke their veto when they judge that a
+serious problem is being ignored, and that their veto is necessary to protect
+the Project. In practice, it turns out that vetoes are almost never
+formally invoked because their mere possibility ensures that Contributors are
+motivated from the start to find solutions that everyone can live with, thus
+accomplishing our goal of ensuring that all interested perspectives are taken
+into account.
+
+How do we know when consensus has been achieved? In principle, this is
+difficult, since consensus is defined by the absence of vetoes, which requires
+us to somehow prove a negative. In practice, we use a combination of our best
+judgment (e.g., a simple and uncontroversial bug fix posted on GitHub and
+reviewed by a core developer is probably fine) and best efforts (e.g.,
+substantive changes must not only follow the Project's CONTRIBUTING document,
+but also be posted to the Project's designated communication channel in order to
+give the broader community a chance to catch any problems and suggest
+improvements; we assume that anyone who cares enough about BMI to invoke their
+veto right should be on the Project's communication channel). If no one comments
+on the Project's communication channel after several days, then it's probably
+fine.
+
+If one does need to invoke a formal veto, then it should consist of:
+
+* an unambiguous statement that a veto is being invoked,
+* an explanation of why it is being invoked, and
+* a description of what conditions (if any) would convince the vetoer to
+  withdraw their veto.
+
+If all proposals for resolving some issue are vetoed, then the status quo wins
+by default.
+
+In the worst case, if a Contributor is genuinely misusing their veto in an
+obstructive fashion to the detriment of the Project, then they can be ejected
+from the Project by consensus of the Steering Council--see below.
+
+Steering Council
+................
+
+The Project has a Steering Council (a.k.a. the BMI Council) that consists of
+Project Contributors and Users. The overall role of the Council is to ensure,
+with input from the Community, the long-term well-being of the Project, both
+technically and as a community.
+
+During everyday Project activities, Council Members participate in discussions,
+code reviews, and other Project activities as peers with all other Contributors
+and the Community. In these everyday activities, Council Members do not have any
+special power or privilege through their membership on the Council. However, it
+is expected that because of the quality and quantity of their contributions and
+their expert knowledge of the Project that Council Members will provide useful
+guidance, both technical and in terms of Project direction, to potentially less
+experienced Contributors.
+
+The Steering Council plays a special role in certain situations. In particular,
+the Council may, if necessary:
+
+* Make decisions about the overall scope, vision, and direction of the Project.
+* Make decisions about strategic collaborations with other organizations or
+  individuals.
+* Make decisions about specific technical issues, features, bugs, and pull
+  requests. They are the primary mechanism of guiding the code review process and
+  merging pull requests.
+* Update policy documents such as this one.
+* Make decisions when regular community discussion doesn’t produce consensus on
+  an issue in a reasonable time frame.
+
+However, the Council's primary responsibility is to facilitate the ordinary
+community-based decision making procedure described above. If the Council ever
+has to step in and formally override the community for the health of the
+Project, then they will do so, but they will consider reaching this point to
+indicate a failure in their leadership.
+
+Council decision making
+.......................
+
+If it becomes necessary for the Steering Council to produce a formal decision,
+then they will use a form of the `Apache Foundation voting process`_. This is a
+formalized version of consensus, in which +1 votes indicate agreement, -1 votes
+are vetoes (and must be accompanied with a rationale, as above), and fractional
+votes (e.g. -0.5, +0.5) can be used if one wishes to express an opinion without
+registering a full veto. These numeric votes can also be used informally to get
+a general sense of the Community's feelings on some issue. A formal vote only
+occurs if explicitly declared, and if this does occur then the vote should be
+held open for long enough to give all interested Council Members a chance to
+respond--at least one week.
+
+In practice, we anticipate that for most Council decisions (e.g., voting in new
+members) a more informal process will suffice.
+
+Council membership
+..................
+
+A list of current Steering Council Members is maintained at the page `Steering
+Council`_.
+
+To become eligible to join the Steering Council, an individual must be a Project
+Contributor who has produced substantial contributions or a Project User that
+has applied BMI in a substantial way. Candidate Council Members are nominated by
+existing Council Members. The Candidate must confirm they are interested and
+willing to serve in this capacity. The Candidate becomes a Member following
+consensus of the existing Council. The Council will be initially formed from a
+set of existing Project Contributors and Users who, as of early 2022, have been
+currently active in Project development or application.
+
+When considering potential Members, the Council will look at candidates with a
+comprehensive view, including but not limited to code, code review,
+applications, infrastructure work, communication channel participation,
+community help/building, education and outreach, design work, etc. We are
+deliberately not setting arbitrary quantitative metrics (like "100 commits in
+this repo") to avoid encouraging behavior that plays to the metrics rather than
+the Project's overall well-being. We want to encourage a diverse array of
+backgrounds, viewpoints, and talents, which is why we explicitly do not define
+code as the sole metric on which Council membership will be evaluated.
+
+If a Council Member becomes inactive in the Project for a period of one year,
+they will be considered for removal from the Council. Before removal, the
+inactive Member will be approached to see if they plan on returning to active
+participation. If not, they will be removed after a Council vote. If they plan
+on returning to active participation, they will be given a grace period of one
+year. If they do not return to active participation within that time period they
+will be removed by vote of the Council without further grace period. All former
+Council Members can be considered for membership again at any time in the
+future, like any other Project Contributor or User. Retired Council members will
+be listed on the project website, acknowledging the period during which they
+were active in the Council.
+
+The Council reserves the right to eject current Members if they are deemed to be
+actively harmful to the Project's well-being, and if attempts at communication
+and conflict resolution have failed. This requires the consensus of the
+remaining Members.
+
+Conflict of interest
+....................
+
+It is expected that Council Members will be employed at a range of universities,
+government agencies, companies, and non-profit organizations. Because of this,
+it is possible that Members will have conflict of interests. Such conflict of
+interests include, but are not limited to:
+
+* Financial interests, such as investments, employment or contracting work,
+  outside of the Project that may influence their work on the Project.
+* Access to proprietary information of their employer that could potentially leak
+  into their work with the Project.
+
+All members of the Council shall disclose to the rest of the Council any
+conflict of interest they may have. Members with a conflict of interest in a
+particular issue may participate in Council discussions on that issue, but must
+recuse themselves from voting on the issue.
+
+Private communications of the Council
+.....................................
+
+To the maximum extent possible, Council discussions and activities will be
+public and done in collaboration and discussion with the Project Contributors
+and Community. The Council will have a private communication channel that will
+be used sparingly and only when a specific matter requires privacy. When private
+communications and decisions are needed, the Council will do its best to
+summarize those to the Community after eliding personal/private/sensitive
+information that should not be posted to the public internet.
+
+Subcommittees
+.............
+
+The Council can create subcommittees that provide leadership and guidance for
+specific aspects of the Project. Like the Council as a whole, subcommittees
+should conduct their business in an open and public manner unless privacy is
+specifically called for. Private subcommittee communications should happen on
+the communication channel of the Council unless specifically called for.
+
+Institutional Partners and Funding
+----------------------------------
+
+The Steering Council is the primary leadership for the Project. No outside
+institution, individual, or legal entity has the ability to own, control, usurp
+or influence the Project other than by participating in the Project as
+Contributors and Council Members. However, because institutions can be an
+important funding mechanism for the project, it is important to formally
+acknowledge institutional participation in the Project. These are Institutional
+Partners.
+
+An Institutional Contributor is any individual Project Contributor who
+contributes to the project as part of their official duties as an Institutional
+Partner. Likewise, an Institutional Council Member is any Project Steering
+Council Member who contributes to the Project as part of their official duties
+as an Institutional Partner.
+
+With these definitions, an Institutional Partner is any recognized legal entity
+in the United States or elsewhere that employs at least one Institutional
+Contributor or Institutional Council Member. Institutional Partners can be
+for-profit or non-profit entities.
+
+Institutions become eligible to become an Institutional Partner by employing
+individuals who actively contribute to the Project as part of their official
+duties. To state this another way, the only way for a Partner to influence the
+project is by actively contributing to the open development of the Project, in
+equal terms to any other Contributor or Council Member. Merely using Project
+software in an institutional context does not allow an entity to become an
+Institutional Partner. Financial gifts do not enable an entity to become an
+Institutional Partner. Once an institution becomes eligible for Institutional
+Partnership, the Steering Council must nominate and approve the Partnership.
+
+If at some point an existing Institutional Partner stops having any contributing
+employees, then a one-year grace period commences. If at the end of this one
+year period they continue not to have any contributing employees, then their
+Institutional Partnership will lapse, and resuming it will require going through
+the normal process for new Partnerships.
+
+An Institutional Partner is free to pursue funding for their work on the Project
+through any legal means. This could involve a non-profit organization raising
+money from private foundations and donors or a for-profit company building
+proprietary products and services that leverage Project software and services.
+Funding acquired by Institutional Partners to work on the Project is called
+Institutional Funding. However, no funding obtained by an Institutional Partner
+can override the Steering Council. If a Partner has funding to do Project work
+and the Council decides to not pursue that work, the Partner is free to pursue
+it on their own. However in this situation, that part of the Partner's work will
+not be under the Project umbrella and cannot use the Project trademarks in a way
+that suggests a formal relationship.
+
+Institutional Partner benefits are:
+
+* Acknowledgement on Project websites, in talks, and on promotional material.
+* Ability to acknowledge their own funding sources on Project websites, in
+  talks, and on promotional material.
+* Ability to influence the Project through the participation of their Council
+  Member.
+
+A list of current Institutional Partners is maintained at the page 
+`Institutional Partners`_.
+
+Document history
+----------------
+
+https://github.com/csdms/bmi/commits/master/docs/source/governance.rst
+
+Acknowledgements
+----------------
+
+Substantial portions of this document were adapted from the `NumPy governance
+document`_.
+
+License
+-------
+
+To the extent possible under law, the authors have waived all copyright and
+related or neighboring rights to the BMI project governance and decision-making
+document, as per the `CC-0 public domain dedication / license`_.
+
+
+
+.. Links
+
+.. _Community Surface Dynamics Modeling System: https://csdms.colorado.edu
+.. _CONTRIBUTING: https://github.com/csdms/bmi/blob/master/CONTRIBUTING.rst
+.. _Chapter 4: Social and Political Infrastructure
+.. _Social and Political Infrastructure: http://producingoss.com/en/producingoss.html#social-infrastructure
+.. _Consensus-based Democracy: http://producingoss.com/en/producingoss.html#consensus-democracy
+.. _Apache Foundation voting process: https://www.apache.org/foundation/voting.html
+.. _Steering Council: ./council.html
+.. _Institutional Partners: ./partners.html
+.. _NumPy governance document: https://numpy.org/doc/stable/dev/governance/index.html
+.. _CC-0 public domain dedication / license: https://creativecommons.org/publicdomain/zero/1.0/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,8 +26,9 @@ BMI is an element of the `CSDMS Workbench`_,
 an integrated system of software tools, technologies, and standards
 for building and coupling models.
 
+
 Help
-====
+----
 
 Adding a BMI to a model can be a daunting task.
 If you'd like assistance,
@@ -37,7 +38,7 @@ Feel free to contact us through the `CSDMS Help Desk`_.
 
 
 Project Information
-===================
+-------------------
 
 .. toctree::
    :maxdepth: 1
@@ -46,6 +47,9 @@ Project Information
    contributing
    conduct
    credits
+   Governance <governance>
+   council
+   partners
 
 
 .. Links:

--- a/docs/source/partners.rst
+++ b/docs/source/partners.rst
@@ -1,0 +1,4 @@
+Institutional Partners
+======================
+
+* Community Surface Dynamics Modeling System


### PR DESCRIPTION
This PR adds draft governance documents for the BMI project. They're based on similar [documents](https://numpy.org/doc/stable/dev/governance/index.html) for the NumPy project. They have passed an initial review by @mcflugen and @gregtucker.

Note that there are (mostly) empty pages for the Steering Council and Institutional Partners. These pages will be filled in when the first Steering Council is assembled.