### PR TITLE
Fix error in get_grid_[xyz] documentation

### DIFF
--- a/docs/source/bmi.grid_funcs.rst
+++ b/docs/source/bmi.grid_funcs.rst
@@ -234,7 +234,7 @@ Get the locations of the grid :term:`nodes <node>` in the first
 coordinate direction.
 
 The length of the resulting one-dimensional array depends on the grid type.
-(It will have either :ref:`get_grid_rank` or :ref:`get_grid_size` elements.)
+(It will use a value from either :ref:`get_grid_shape` or :ref:`get_grid_size`.)
 See :ref:`model_grids` for more information.
 
 **Implementation notes**
@@ -264,7 +264,7 @@ Get the locations of the grid :term:`nodes <node>` in the second
 coordinate direction.
 
 The length of the resulting one-dimensional array depends on the grid type.
-(It will have either :ref:`get_grid_rank` or :ref:`get_grid_size` elements.)
+(It will use a value from either :ref:`get_grid_shape` or :ref:`get_grid_size`.)
 See :ref:`model_grids` for more information.
 
 **Implementation notes**
@@ -294,7 +294,7 @@ Get the locations of the grid :term:`nodes <node>` in the third
 coordinate direction.
 
 The length of the resulting one-dimensional array depends on the grid type.
-(It will have either :ref:`get_grid_rank` or :ref:`get_grid_size` elements.)
+(It will use a value from either :ref:`get_grid_shape` or :ref:`get_grid_size`.)
 See :ref:`model_grids` for more information.
 
 **Implementation notes**

--- a/docs/source/model_grids.rst
+++ b/docs/source/model_grids.rst
@@ -84,10 +84,10 @@ an array of coordinates for each row and column
 (for the two-dimensional case) is required.
 
 The :ref:`get_grid_y` function provides an array (whose length is the number of
-*rows*) that gives the *y*-coordinate for each row.
+*rows*, obtained from :ref:`get_grid_shape`) that gives the *y*-coordinate for each row.
 
 The :ref:`get_grid_x` function provides an array (whose length is the number of
-*columns*) that gives the *x*-coordinate for each column.
+*columns*, obtained from :ref:`get_grid_shape`) that gives the *x*-coordinate for each column.
 
 Rectilinear grids use the following BMI functions:
 


### PR DESCRIPTION
This PR fixes #97, where the wrong function is suggested to get the length of the vector of values from the *get_grid_[xyz]* functions.