### PR TITLE
Added get_bmi_version to sidl and documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Contributors
 * Greg Tucker
 * Ben van Werkhoven
 * Martijn Visser
+* Rolf Hut
 
 If you have contributed to the BMI project and your name is missing,
 please send an email to the coordinators, or open a pull request

--- a/bmi.sidl
+++ b/bmi.sidl
@@ -1,9 +1,12 @@
 //
 // The Basic Model Interface (BMI)
 //
-package csdms version 2.0 {
+package csdms version 2.1 {
   interface bmi {
 
+    // Metadata on model and BMI
+    int get_bmi_version(out string version);    
+	
     // Initialize, run, finalize (IRF)
     int initialize(in string config_file);
     int update();

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -31,6 +31,28 @@ but it should be unique to prevent conflicts with other components.
 
 [:ref:`info_funcs` | :ref:`basic_model_interface`]
 
+.. _get_bmi_version:
+
+*get_bmi_version*
+....................
+
+.. code-block:: java
+
+  /* SIDL */
+  int get_bmi_version(out string version);
+
+This function version of BMI implemented as a string.
+This should always be higher than 2.0 since this function was introduced in BMI 2.1
+
+**Implementation notes**
+
+* In C and Fortran, the *version* argument is a a character array, and an integer
+  status code indicating success (zero) or failure (nonzero) is returned.
+* In C++, Java, and Python, this argument is omitted, and a string -- a basic type
+  in these languages -- is returned from the function.
+
+[:ref:`info_funcs` | :ref:`basic_model_interface`]
+
 
 .. _get_input_item_count:
 

--- a/docs/source/bmi.spec.rst
+++ b/docs/source/bmi.spec.rst
@@ -97,6 +97,7 @@ grouped by functional category.
    :ref:`update_until`             Advance model state until the given time.
    :ref:`finalize`                 Perform tear-down tasks for the model.
    :ref:`get_component_name`       Name of the model.
+   :ref:`get_bmi_version`          Version number of the BMI version implemented.
    :ref:`get_input_item_count`     Count of a model's input variables.
    :ref:`get_output_item_count`    Count of a model's output variables.
    :ref:`get_input_var_names`      List of a model's input variables.


### PR DESCRIPTION
solves #8 

@mcflugen and I added get_bmi_version to the sidl and the documentation, but it still needs to be added to the different repos of the language specific bindings.
