### PR TITLE
Include instruction to use release in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ is supported by the National Science Foundation.*
 .. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
 .. _bmi-example-java: https://github.com/csdms/bmi-example-java
 .. _bmi-example-python: https://github.com/csdms/bmi-example-python
-.. _latest_release: https://github.com/csdms/bmi/releases
+.. _latest release: https://github.com/csdms/bmi/releases
 .. _Basic Model Interface 2.0: https://github.com/csdms/bmi/releases/tag/v2.0
 .. _documentation: https://bmi.readthedocs.io
 .. _CSDMS Workbench: https://csdms.colorado.edu/wiki/Workbench

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 
    <p align="center">
       <a href='https://bmi.readthedocs.org/'>
-         <img src='https://github.com/csdms/bmi/raw/master/docs/source/_static/bmi-logo-header-text.png'/>
+         <img src='https://github.com/csdms/bmi/raw/develop/docs/source/_static/bmi-logo-header-text.png'/>
       </a>
    </p>
 

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ See the links above for details.
 The default branch of this repository
 reflects the current state of development for the BMI.
 When implementing a BMI,
-please use the latest release listed in the right sidebar;
+please use the `latest release`_ listed in the right sidebar;
 currently this is `Basic Model Interface 2.0`_.
 For more information on implementing a BMI,
 see the `documentation`_.
@@ -122,6 +122,7 @@ is supported by the National Science Foundation.*
 .. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
 .. _bmi-example-java: https://github.com/csdms/bmi-example-java
 .. _bmi-example-python: https://github.com/csdms/bmi-example-python
+.. _latest_release: https://github.com/csdms/bmi/releases
 .. _Basic Model Interface 2.0: https://github.com/csdms/bmi/releases/tag/v2.0
 .. _documentation: https://bmi.readthedocs.io
 .. _CSDMS Workbench: https://csdms.colorado.edu/wiki/Workbench

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,14 @@ Alternatively, the specifications can be installed through conda
 (C, C++, Fortran, Python) or Maven (Java).
 See the links above for details.
 
+The default branch of this repository
+reflects the current state of development for the BMI.
+When implementing a BMI,
+please use the latest release listed in the right sidebar;
+currently this is `Basic Model Interface 2.0`_.
+For more information on implementing a BMI,
+see the `documentation`_.
+
 While CSDMS currently supports the languages listed above,
 a BMI can be written for any language.
 BMI is a community-driven standard;
@@ -114,4 +122,6 @@ is supported by the National Science Foundation.*
 .. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
 .. _bmi-example-java: https://github.com/csdms/bmi-example-java
 .. _bmi-example-python: https://github.com/csdms/bmi-example-python
+.. _Basic Model Interface 2.0: https://github.com/csdms/bmi/releases/tag/v2.0
+.. _documentation: https://bmi.readthedocs.io
 .. _CSDMS Workbench: https://csdms.colorado.edu/wiki/Workbench


### PR DESCRIPTION
Since the default branch of the BMI repository is used for development, we should note that when implementing a BMI
the latest tagged release should be used (e.g., [v2.0](https://github.com/csdms/bmi/releases/tag/v2.0)), not the tip of the default branch.

This PR adds this note. It also fixes a broken link.
