### PR TITLE
Add contributed BMI language specs and examples

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,8 @@ Contributors
 ------------
 
 * Richard Barnes
+* Ibrahim Demir
+* Greg Ewing
 * Michael Galloy
 * Julian Hofer
 * Eric Hutton
@@ -20,10 +22,12 @@ Contributors
 * Boyana Norris
 * Scott Peckham
 * Mark Piper
+* Carlos Erazo Ramirez
 * Mike Taves
 * Greg Tucker
-* Ben van Werkhoven
+* Ashani Vaidya
 * Martijn Visser
+* Ben van Werkhoven
 
 If you have contributed to the BMI project and your name is missing,
 please send an email to the coordinators, or open a pull request

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ For each language,
 links to the specification and an example implementation
 are listed in the table below.
 
-.. table::
+.. table:: BMI languages
    :align: center
    :widths: 10, 10, 15
 
@@ -97,7 +97,7 @@ The table below lists community-contributed
 language specifications and examples
 for two languages, Javascript and Julia.
 
-.. table::
+.. table:: Community-contributed BMI languages
    :align: center
    :widths: 10, 10, 15
 

--- a/README.rst
+++ b/README.rst
@@ -86,12 +86,36 @@ Alternatively, the specifications can be installed through conda
 See the links above for details.
 
 While CSDMS currently supports the languages listed above,
-a BMI can be written for any language.
+a BMI specification can be written for any language.
 BMI is a community-driven standard;
 `contributions <CONTRIBUTING.rst>`_
 that follow the `contributor code of conduct <./CODE-OF-CONDUCT.rst>`_
 are welcomed,
 and are `acknowledged <./AUTHORS.rst>`_.
+
+The table below lists community-contributed
+language specifications and examples
+for two languages, Javascript and Julia.
+
+.. table::
+   :align: center
+   :widths: 10, 10, 15
+
+   ==========  =============  ======================
+   Language    Specification  Example implementation
+   ==========  =============  ======================
+   Javascript  `bmi-js`_      `bmi-example-js`_
+   Julia       `bmi-julia`_   `bmi-example-julia`_
+   ==========  =============  ======================
+
+The default branch of this repository
+reflects the current state of development for the BMI.
+When implementing a BMI,
+please use the `latest release`_ listed in the right sidebar;
+currently this is `Basic Model Interface 2.0`_.
+For more information on implementing a BMI,
+see the `documentation`_.
+
 BMI is open source software released under the `MIT License <./LICENSE>`_.
 BMI is an element of the `CSDMS Workbench`_,
 an integrated system of software tools, technologies, and standards
@@ -110,9 +134,16 @@ is supported by the National Science Foundation.*
 .. _bmi-fortran: https://github.com/csdms/bmi-fortran
 .. _bmi-java: https://github.com/csdms/bmi-java
 .. _bmi-python: https://github.com/csdms/bmi-python
+.. _bmi-js: https://github.com/uihilab/bmi-js
+.. _bmi-julia: https://github.com/Deltares/BasicModelInterface.jl
 .. _bmi-example-c: https://github.com/csdms/bmi-example-c
 .. _bmi-example-cxx: https://github.com/csdms/bmi-example-cxx
 .. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
 .. _bmi-example-java: https://github.com/csdms/bmi-example-java
 .. _bmi-example-python: https://github.com/csdms/bmi-example-python
+.. _bmi-example-js: https://github.com/uihilab/bmi-example-js
+.. _bmi-example-julia: https://github.com/csdms/bmi-example-julia
+.. _latest release: https://github.com/csdms/bmi/releases
+.. _Basic Model Interface 2.0: https://github.com/csdms/bmi/releases/tag/v2.0
+.. _documentation: https://bmi.readthedocs.io
 .. _CSDMS Workbench: https://csdms.colorado.edu/wiki/Workbench

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 
    <p align="center">
       <a href='https://bmi.readthedocs.org/'>
-         <img src='https://github.com/csdms/bmi/raw/master/docs/source/_static/bmi-logo-header-text.png'/>
+         <img src='https://github.com/csdms/bmi/raw/develop/docs/source/_static/bmi-logo-header-text.png'/>
       </a>
    </p>
 

--- a/README.rst
+++ b/README.rst
@@ -38,16 +38,16 @@
 
    </p>
 
-The *Basic Model Interface* (BMI) is a library specification
-created by the `Community Surface Dynamics Modeling System`_ (CSDMS)
-to facilitate the conversion of a model or dataset
-into a reusable, plug-and-play component.
-Recall that in this context an interface is a named set of functions
-with prescribed arguments and return values.
-The BMI functions make a model self-describing and fully controllable
+The *Basic Model Interface* (BMI),
+developed by the `Community Surface Dynamics Modeling System`_ (CSDMS),
+is a standardized set of control and query functions that,
+when added to a software element such as a model or a dataset,
+makes that software easier to couple with other software that also exposes a BMI.
+
+A BMI makes a model self-describing and fully controllable
 by a modeling framework or application.
 By design, the BMI functions are straightforward to implement in
-any language, using only basic data types from standard language libraries.
+any language, using basic data types from standard language libraries.
 Also by design, the BMI functions are noninvasive.
 This means that a model's BMI does not make calls to other
 components or tools and is not modified to use any
@@ -56,10 +56,11 @@ dependencies into a model, so the model can still be used
 in a stand-alone manner.
 
 The BMI is expressed
-in the `Scientific Interface Definition Language`_ (SIDL)
-in the file `bmi.sidl <./bmi.sidl>`_.
-BMI specifications for five languages -- C, C++, Fortran, Java,
-and Python -- are derived from this SIDL file.
+in the `Scientific Interface Definition Language`_ (SIDL).
+From `bmi.sidl <./bmi.sidl>`_,
+CSDMS has derived BMI specifications
+for five languages--C, C++, Fortran, Java,
+and Python.
 For each language,
 links to the specification and an example implementation
 are listed in the table below.

--- a/docs/source/bmi.spec.rst
+++ b/docs/source/bmi.spec.rst
@@ -13,13 +13,13 @@ can be grouped into categories:
 * :ref:`getter_setter_funcs`
 * :ref:`grid_funcs`
 
-Table 2 lists the individual BMI functions
+Table 3 lists the individual BMI functions
 along with a brief description.
 Following the table is a detailed description of each function,
 including the function prototype in :term:`SIDL`,
 grouped by functional category.
 
-.. table:: **Table 2:** Summary of BMI functions.
+.. table:: **Table 3:** Summary of BMI functions.
    :align: center
    :widths: 30, 70
 

--- a/docs/source/bmi.spec.rst
+++ b/docs/source/bmi.spec.rst
@@ -1,69 +1,3 @@
-When you climb in the driver's seat of an unfamiliar car,
-you are nonetheless presented with a familiar sight.
-Whatever the make or model may be,
-we take it for granted that the vehicle will provide
-a steering wheel, brake pedal, and speedometer,
-alongside the various other controls and readouts
-that are common to essentially all cars and trucks on the planet.
-Although we don't usually think of it this way,
-drivers across the globe benefit from a standard interface:
-a set of control mechanisms and information displays
-that have essentially the same design regardless of whether the vehicle
-is a tiny electric two-seater or a giant stretch limousine.
-This standard interface makes the job of operating a vehicle much easier
-than it would be if each one presented a radically different interface.
-Imagine a world where switching from a sports car to a pickup truck
-required months of study and practice!
-Similarly, railroads benefit from a standard for coupling rail cars together.
-The result: trains can be assembled from combinations of all sorts
-of different rail cars, built by different companies,
-in different places, and with different purposes.
-
-We believe that numerical models,
-and the sub-components that make up those models,
-should offer a similar kind of standardization.
-To this end,
-the `Community Surface Dynamics Modeling System`_ (CSDMS)
-has developed the *Basic Model Interface* (BMI):
-a set of standard control and query functions that,
-when added to a model code,
-make that model both easier to learn
-and easier to couple with other software elements.
-
-While a BMI can be written for any language,
-CSDMS currently supports five languages:
-C, C++, Fortran, Java, and Python.
-The specification for each language is given in Table 1,
-along with a corresponding example
-in which the BMI is implemented.
-
-.. _specs_and_examples:
-
-.. table:: **Table 1:** BMI language specifications.
-   :align: center
-   :widths: 20, 25, 25, 30
-
-   ========  =============  ==============  ======================
-   Language  Specification  Repository      Example
-   ========  =============  ==============  ======================
-   C         `bmi.h`_       `bmi-c`_        `bmi-example-c`_
-   C++       `bmi.hxx`_     `bmi-cxx`_      `bmi-example-cxx`_
-   Fortran   `bmi.f90`_     `bmi-fortran`_  `bmi-example-fortran`_ 
-   Java      `bmi.java`_    `bmi-java`_     `bmi-example-java`_ 
-   Python    `bmi.py`_      `bmi-python`_   `bmi-example-python`_
-   ========  =============  ==============  ======================
-
-Along with the examples,
-two documents may be particularly helpful when writing a BMI:
-
-* :ref:`Getting Started Guide <getting_started>` --- a place to start
-  if you haven't written a BMI before
-* :ref:`BMI Best Practices <best_practices>` --- our collected wisdom on
-  implementing a BMI
-
-A complete description of the functions that make up the BMI is given next.
-
-
 .. _basic_model_interface:
 
 The Basic Model Interface
@@ -146,22 +80,6 @@ grouped by functional category.
 ..
    Links
 
-.. _Community Surface Dynamics Modeling System: https://csdms.colorado.edu
-.. _bmi.h: https://github.com/csdms/bmi-c/blob/master/bmi.h
-.. _bmi.hxx: https://github.com/csdms/bmi-cxx/blob/master/bmi.hxx
-.. _bmi.f90: https://github.com/csdms/bmi-fortran/blob/master/bmi.f90
-.. _bmi.java: https://github.com/csdms/bmi-java/blob/master/src/main/java/edu/colorado/csdms/bmi/BMI.java
-.. _bmi.py: https://github.com/csdms/bmi-python/blob/master/bmipy/bmi.py
-.. _bmi-c: https://github.com/csdms/bmi-c
-.. _bmi-cxx: https://github.com/csdms/bmi-cxx
-.. _bmi-fortran: https://github.com/csdms/bmi-fortran
-.. _bmi-java: https://github.com/csdms/bmi-java
-.. _bmi-python: https://github.com/csdms/bmi-python
-.. _bmi-example-c: https://github.com/csdms/bmi-example-c
-.. _bmi-example-cxx: https://github.com/csdms/bmi-example-cxx
-.. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
-.. _bmi-example-java: https://github.com/csdms/bmi-example-java
-.. _bmi-example-python: https://github.com/csdms/bmi-example-python
 .. _UDUNITS: http://www.unidata.ucar.edu/software/udunits/
 .. _The Units Database: https://www.unidata.ucar.edu/software/udunits/udunits-current/doc/udunits/udunits2.html#Database
 .. _time unit conventions: https://www.unidata.ucar.edu/software/udunits/udunits-current/udunits/udunits2-accepted.xml

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,7 +47,7 @@ in which the BMI is implemented.
 
 .. _specs_and_examples:
 
-.. table:: **Table 1:** BMI language specifications.
+.. table:: **Table 1:** BMI languages.
    :align: center
    :widths: 20, 25, 25, 30
 
@@ -60,6 +60,21 @@ in which the BMI is implemented.
    Java      `bmi.java`_    `bmi-java`_     `bmi-example-java`_ 
    Python    `bmi.py`_      `bmi-python`_   `bmi-example-python`_
    ========  =============  ==============  ======================
+
+BMI is a community standard.
+Table 2 lists community-contributed language specifications and examples
+for two languages, Javascript and Julia.
+
+.. table:: **Table 2:** Community-contributed BMI languages.
+   :align: center
+   :widths: 20, 25, 25, 30
+
+   ==========  =============  ============  =====================
+   Language    Specification  Repository    Example
+   ==========  =============  ============  =====================
+   Javascript  `bmi.js`_      `bmi-js`_     `bmi-example-js`_ 
+   Julia       `bmi.jl`_      `bmi-julia`_  `bmi-example-julia`_
+   ==========  =============  ============  =====================
 
 Along with the examples,
 two documents may be particularly helpful when writing a BMI:
@@ -125,15 +140,21 @@ Project Information
 .. _bmi.f90: https://github.com/csdms/bmi-fortran/blob/master/bmi.f90
 .. _bmi.java: https://github.com/csdms/bmi-java/blob/master/src/main/java/edu/colorado/csdms/bmi/BMI.java
 .. _bmi.py: https://github.com/csdms/bmi-python/blob/master/bmipy/bmi.py
+.. _bmi.js: https://github.com/uihilab/BMI-JS/blob/main/bmijs/bmi.js
+.. _bmi.jl: https://github.com/Deltares/BasicModelInterface.jl/blob/master/src/BasicModelInterface.jl
 .. _bmi-c: https://github.com/csdms/bmi-c
 .. _bmi-cxx: https://github.com/csdms/bmi-cxx
 .. _bmi-fortran: https://github.com/csdms/bmi-fortran
 .. _bmi-java: https://github.com/csdms/bmi-java
 .. _bmi-python: https://github.com/csdms/bmi-python
+.. _bmi-js: https://github.com/uihilab/bmi-js
+.. _bmi-julia: https://github.com/Deltares/BasicModelInterface.jl
 .. _bmi-example-c: https://github.com/csdms/bmi-example-c
 .. _bmi-example-cxx: https://github.com/csdms/bmi-example-cxx
 .. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
 .. _bmi-example-java: https://github.com/csdms/bmi-example-java
 .. _bmi-example-python: https://github.com/csdms/bmi-example-python
+.. _bmi-example-js: https://github.com/uihilab/bmi-example-js
+.. _bmi-example-julia: https://github.com/csdms/bmi-example-julia
 .. _CSDMS Workbench: https://csdms.colorado.edu/wiki/Workbench
 .. _CSDMS Help Desk: https://github.com/csdms/help-desk

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,71 @@
 
 .. title:: BMI
 
+When you climb in the driver's seat of an unfamiliar car,
+you are nonetheless presented with a familiar sight.
+Whatever the make or model may be,
+we take it for granted that the vehicle will provide
+a steering wheel, brake pedal, and speedometer,
+alongside the various other controls and readouts
+that are common to essentially all cars and trucks on the planet.
+Although we don't usually think of it this way,
+drivers across the globe benefit from a standard interface:
+a set of control mechanisms and information displays
+that have essentially the same design regardless of whether the vehicle
+is a tiny electric two-seater or a giant stretch limousine.
+This standard interface makes the job of operating a vehicle much easier
+than it would be if each one presented a radically different interface.
+Imagine a world where switching from a sports car to a pickup truck
+required months of study and practice!
+Similarly, railroads benefit from a standard for coupling rail cars together.
+The result: trains can be assembled from combinations of all sorts
+of different rail cars, built by different companies,
+in different places, and with different purposes.
+
+We believe that numerical models,
+and the sub-components that make up those models,
+should offer a similar kind of standardization.
+To this end,
+the `Community Surface Dynamics Modeling System`_ (CSDMS)
+has developed the *Basic Model Interface* (BMI):
+a set of standard control and query functions that,
+when added to a model code,
+make that model both easier to learn
+and easier to couple with other software elements.
+
+While a BMI can be written for any language,
+CSDMS currently supports five languages:
+C, C++, Fortran, Java, and Python.
+The specification for each language is given in Table 1,
+along with a corresponding example
+in which the BMI is implemented.
+
+.. _specs_and_examples:
+
+.. table:: **Table 1:** BMI language specifications.
+   :align: center
+   :widths: 20, 25, 25, 30
+
+   ========  =============  ==============  ======================
+   Language  Specification  Repository      Example
+   ========  =============  ==============  ======================
+   C         `bmi.h`_       `bmi-c`_        `bmi-example-c`_
+   C++       `bmi.hxx`_     `bmi-cxx`_      `bmi-example-cxx`_
+   Fortran   `bmi.f90`_     `bmi-fortran`_  `bmi-example-fortran`_ 
+   Java      `bmi.java`_    `bmi-java`_     `bmi-example-java`_ 
+   Python    `bmi.py`_      `bmi-python`_   `bmi-example-python`_
+   ========  =============  ==============  ======================
+
+Along with the examples,
+two documents may be particularly helpful when writing a BMI:
+
+* :ref:`Getting Started Guide <getting_started>` --- a place to start
+  if you haven't written a BMI before
+* :ref:`BMI Best Practices <best_practices>` --- our collected wisdom on
+  implementing a BMI
+
+A complete description of the functions that make up the BMI is given next.
+
 .. include:: bmi.spec.rst
 
 
@@ -54,5 +119,21 @@ Project Information
 
 .. Links:
 
+.. _Community Surface Dynamics Modeling System: https://csdms.colorado.edu
+.. _bmi.h: https://github.com/csdms/bmi-c/blob/master/bmi.h
+.. _bmi.hxx: https://github.com/csdms/bmi-cxx/blob/master/bmi.hxx
+.. _bmi.f90: https://github.com/csdms/bmi-fortran/blob/master/bmi.f90
+.. _bmi.java: https://github.com/csdms/bmi-java/blob/master/src/main/java/edu/colorado/csdms/bmi/BMI.java
+.. _bmi.py: https://github.com/csdms/bmi-python/blob/master/bmipy/bmi.py
+.. _bmi-c: https://github.com/csdms/bmi-c
+.. _bmi-cxx: https://github.com/csdms/bmi-cxx
+.. _bmi-fortran: https://github.com/csdms/bmi-fortran
+.. _bmi-java: https://github.com/csdms/bmi-java
+.. _bmi-python: https://github.com/csdms/bmi-python
+.. _bmi-example-c: https://github.com/csdms/bmi-example-c
+.. _bmi-example-cxx: https://github.com/csdms/bmi-example-cxx
+.. _bmi-example-fortran: https://github.com/csdms/bmi-example-fortran
+.. _bmi-example-java: https://github.com/csdms/bmi-example-java
+.. _bmi-example-python: https://github.com/csdms/bmi-example-python
 .. _CSDMS Workbench: https://csdms.colorado.edu/wiki/Workbench
 .. _CSDMS Help Desk: https://github.com/csdms/help-desk


### PR DESCRIPTION
This PR adds links in the documentation and the README to the community-contributed BMI language specifications and examples for Javascript and Julia.

Thank you to @visr (Julia) and @gregjewi and his colleagues (Javascript) for their contributions!

This resolves #108.

