### PR TITLE
Update intersphinx format

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -314,4 +314,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
This PR updates the format used by the `intersphinx_mapping` configuration for the intersphinx extension.

See https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
