### PR TITLE
Fix typos

### DIFF
--- a/docs/source/bmi.best_practices.rst
+++ b/docs/source/bmi.best_practices.rst
@@ -46,7 +46,7 @@ here are some tips to help when writing a BMI for a model.
   responsibility to ensure that array information is
   flattened/redimensionalized in the correct order.
 
-* Recall that models can have mulitple grids. This can be particularly
+* Recall that models can have multiple grids. This can be particularly
   useful for defining :term:`exchange items <exchange item>` that
   don't vary over the model domain; e.g., a diffusivity -- just define
   the variable on a separate :ref:`scalar grid <unstructured_grids>`.

--- a/docs/source/governance.rst
+++ b/docs/source/governance.rst
@@ -304,7 +304,7 @@ that suggests a formal relationship.
 
 Institutional Partner benefits are:
 
-* Acknowledgement on Project websites, in talks, and on promotional material.
+* Acknowledgment on Project websites, in talks, and on promotional material.
 * Ability to acknowledge their own funding sources on Project websites, in
   talks, and on promotional material.
 * Ability to influence the Project through the participation of their Council
@@ -318,8 +318,8 @@ Document history
 
 https://github.com/csdms/bmi/commits/master/docs/source/governance.rst
 
-Acknowledgements
-----------------
+Acknowledgments
+---------------
 
 Substantial portions of this document were adapted from the `NumPy governance
 document`_.

--- a/docs/source/model_grids.rst
+++ b/docs/source/model_grids.rst
@@ -52,7 +52,7 @@ where the elements have equal width in each dimension.
 That is, for a two-dimensional grid, elements have a constant width
 of ``dx`` in the *x*-direction and ``dy`` in the *y*-direction.
 The case of ``dx == dy`` is oftentimes called
-a *raster* or *Catesian grid*.
+a *raster* or *Cartesian grid*.
 
 To completely specify a uniform rectilinear grid,
 only three pieces of information are needed:


### PR DESCRIPTION
Result of running ispell over `/*.rst` and `/docs/source/*.rst`