### PR TITLE
Update docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: html
   configuration: docs/source/conf.py
@@ -9,8 +14,8 @@ formats:
   - htmlzip
 
 python:
-  version: 3.8
-  system_packages: true
-
-build:
-  image: latest
+  install:
+    - requirements: docs/source/requirements.txt
+    - method: pip
+      path: .
+  system_packages: false

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=4
+sphinx_rtd_theme
+readthedocs-sphinx-search

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,11 +31,11 @@ def build_docs(session: nox.Session) -> None:
 @nox.session(python=False, name="clean-docs")
 def clean_docs(session: nox.Session) -> None:
     """Clean up the docs folder."""
-    build_dir = ROOT / "docs" / "build"
+    docs_dir = ROOT / "docs"
 
-    if (build_dir / "html").is_dir():
-        with session.chdir(build_dir):
-            shutil.rmtree("html")
+    if (docs_dir / "build").is_dir():
+        with session.chdir(docs_dir):
+            shutil.rmtree("build")
 
     if (ROOT / "build").is_dir():
         session.chdir(ROOT / "build")
@@ -47,3 +47,5 @@ def clean_docs(session: nox.Session) -> None:
 def nuke(session):
     """Run all clean sessions."""
     clean_docs(session)
+    if (ROOT / "__pycache__").is_dir():
+        shutil.rmtree("__pycache__")


### PR DESCRIPTION
This PR introduces a minor update to the docs build process. Read the Docs recently deprecated the use of system Python packages. They instead recommend using a requirements file for dependencies. I added a requirements file and updated the Read the Docs configuration file to follow the [latest recommendations](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html). I also modified our noxfile to better clean up after a build.