### PR TITLE
Fix docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,9 +10,6 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: false
 
-formats:
-  - htmlzip
-
 python:
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,5 +16,3 @@ formats:
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: pip
-      path: .

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,8 +29,8 @@ def build_docs(session: nox.Session) -> None:
         "html",
         "-W",
         "--keep-going",
-        docs_dir / "source",
-        build_dir / "html",
+        (docs_dir / "source").as_posix(),
+        (build_dir / "html").as_posix(),
     )
     session.log(f"generated docs at {build_dir / 'html'!s}")
 


### PR DESCRIPTION
The docs builds on ReadTheDocs were failing because of issues with the configuration file. This PR fixes those issues. Further, the local build of the docs was also failing, though for unrelated reasons. This is fixed, as well.