### PR TITLE
Fix broken links to UDUNITS docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,8 +30,8 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-          - uses: actions/checkout@v2
-          - uses: actions/setup-python@v2
+          - uses: actions/checkout@v4
+          - uses: actions/setup-python@v5
 
           - name: Install dependencies
             run: pip install nox

--- a/docs/source/bmi.spec.rst
+++ b/docs/source/bmi.spec.rst
@@ -84,7 +84,7 @@ grouped by functional category.
    Links
 
 .. _UDUNITS: https://www.unidata.ucar.edu/software/udunits/
-.. _The Units Database: https://www.unidata.ucar.edu/software/udunits/udunits-current/doc/udunits/udunits2.html#Database
-.. _time unit conventions: https://www.unidata.ucar.edu/software/udunits/udunits-current/udunits/udunits2-accepted.xml
+.. _The Units Database: https://docs.unidata.ucar.edu/udunits/current/#Database
+.. _time unit conventions: https://docs.unidata.ucar.edu/udunits/current/udunits2-accepted.xml
 .. _primitive types: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
 .. _wrapper classes: https://docs.oracle.com/javase/tutorial/java/data/numberclasses.html


### PR DESCRIPTION
This PR updates links to the UDUNITS docs used in the BMI docs.

I also bumped the versions of the actions we use in the *build-docs* CI workflow.

This fixes #145 and #146.
