### PR TITLE
Split the bmi spec into multiple pages

### DIFF
--- a/docs/source/bmi.control_funcs.rst
+++ b/docs/source/bmi.control_funcs.rst
@@ -42,8 +42,6 @@ formatted.
 * In C and Fortran, an integer status code indicating success (zero) or failure (nonzero)
   is returned. In C++, Java, and Python, an exception is raised on failure.
 
-[:ref:`control_funcs` | :ref:`basic_model_interface`]
-
 
 .. _update:
 
@@ -71,8 +69,6 @@ function can just return without doing anything.
 * In C and Fortran, an integer status code indicating success (zero) or failure (nonzero)
   is returned. In C++, Java, and Python, an exception is raised on failure.
 
-[:ref:`control_funcs` | :ref:`basic_model_interface`]
-
 
 .. _update_until:
 
@@ -99,8 +95,6 @@ to reflect that the model was updated to the requested time.
 * In C and Fortran, an integer status code indicating success (zero) or failure (nonzero)
   is returned. In C++, Java, and Python, an exception is raised on failure.
 
-[:ref:`control_funcs` | :ref:`basic_model_interface`]
-
 
 .. _finalize:
 
@@ -121,5 +115,3 @@ deallocating memory, closing files and printing reports.
 
 * In C and Fortran, an integer status code indicating success (zero) or failure (nonzero)
   is returned. In C++, Java, and Python, an exception is raised on failure.
-
-[:ref:`control_funcs` | :ref:`basic_model_interface`]

--- a/docs/source/bmi.getter_setter.rst
+++ b/docs/source/bmi.getter_setter.rst
@@ -164,3 +164,5 @@ Additionally,
 * The *inds* argument is always of type integer.
 
 [:ref:`getter_setter_funcs` | :ref:`basic_model_interface`]
+
+.. include:: links.rst

--- a/docs/source/bmi.getter_setter.rst
+++ b/docs/source/bmi.getter_setter.rst
@@ -49,8 +49,6 @@ even if the model uses dimensional variables.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`getter_setter_funcs` | :ref:`basic_model_interface`]
-
 .. _get_value_ptr:
 
 *get_value_ptr*
@@ -77,8 +75,6 @@ even if the model's state has changed.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`getter_setter_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_value_at_indices:
 
@@ -102,8 +98,6 @@ Additionally,
 
 * Both *dest* and *inds* are flattened arrays.
 * The *inds* argument is always of type integer.
-
-[:ref:`getter_setter_funcs` | :ref:`basic_model_interface`]
 
 
 .. _set_value:
@@ -138,8 +132,6 @@ even if the model uses dimensional variables.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`getter_setter_funcs` | :ref:`basic_model_interface`]
-
 
 .. _set_value_at_indices:
 
@@ -162,7 +154,5 @@ Additionally,
 
 * Both *src* and *inds* are flattened arrays.
 * The *inds* argument is always of type integer.
-
-[:ref:`getter_setter_funcs` | :ref:`basic_model_interface`]
 
 .. include:: links.rst

--- a/docs/source/bmi.grid_funcs.rst
+++ b/docs/source/bmi.grid_funcs.rst
@@ -54,8 +54,6 @@ is given in the :ref:`model_grids` section.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_rank:
 
@@ -84,8 +82,6 @@ of :ref:`get_grid_x`, :ref:`get_grid_y`, etc. are implemented.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_size:
 
@@ -113,8 +109,6 @@ for :ref:`unstructured <unstructured_grids>` and
   size is returned from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_grid_shape:
@@ -154,8 +148,6 @@ the cells.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_spacing:
 
@@ -184,8 +176,6 @@ the spacing between rows is followed by spacing between columns, ``[dy, dx]``.
 * In C++ and Java, this is a void function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_grid_origin:
@@ -217,8 +207,6 @@ the origin is given in the column dimension, followed by the row dimension,
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_x:
 
@@ -246,8 +234,6 @@ See :ref:`model_grids` for more information.
 * In C++ and Java, this is a void function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_grid_y:
@@ -277,8 +263,6 @@ See :ref:`model_grids` for more information.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_z:
 
@@ -307,8 +291,6 @@ See :ref:`model_grids` for more information.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_node_count:
 
@@ -330,8 +312,6 @@ Get the number of :term:`nodes <node>` in the grid.
   count is returned from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_grid_edge_count:
@@ -355,8 +335,6 @@ Get the number of :term:`edges <edge>` in the grid.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_face_count:
 
@@ -378,8 +356,6 @@ Get the number of :term:`faces <face>` in the grid.
   count is returned from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_grid_edge_nodes:
@@ -407,8 +383,6 @@ node at edge head. The total length of the array is
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_face_edges:
 
@@ -433,8 +407,6 @@ The length of the array returned is the sum of the values of
 * In C++ and Java, this is a void function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_grid_face_nodes:
@@ -466,8 +438,6 @@ the length of the array is the sum of the values of
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_grid_nodes_per_face:
 
@@ -492,5 +462,3 @@ The number of edges per face is equal to the number of nodes per face.
 * In C++ and Java, this is a void function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`grid_funcs` | :ref:`basic_model_interface`]

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -29,8 +29,6 @@ but it should be unique to prevent conflicts with other components.
 * In C++, Java, and Python, this argument is omitted, and a string -- a basic type
   in these languages -- is returned from the function.
 
-[:ref:`info_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_input_item_count:
 
@@ -53,8 +51,6 @@ Also the number of variables that can be set with :ref:`set_value`.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`info_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_output_item_count:
 
@@ -76,8 +72,6 @@ Also the number of variables that can be retrieved with :ref:`get_value`.
   returned from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`info_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_input_var_names:
@@ -113,8 +107,6 @@ Standard Names do not have to be used within the model.
   function in a tuple, a standard container in the language.
 * A model might have no input variables.
 
-[:ref:`info_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_output_var_names:
 
@@ -148,5 +140,3 @@ Standard Names do not have to be used within the model.
 * In Python, the argument is omitted and the names are returned from the
   function in a tuple, a standard container in the language.
 * A model may have no output variables.
-
-[:ref:`info_funcs` | :ref:`basic_model_interface`]

--- a/docs/source/bmi.metadata_funcs.rst
+++ b/docs/source/bmi.metadata_funcs.rst
@@ -26,5 +26,3 @@ This function supplies the version of BMI implemented as a string.
   status code indicating success (zero) or failure (nonzero) is returned.
 * In C++, Java, and Python, this argument is omitted, and a string -- a basic type
   in these languages -- is returned from the function.
-
-[:ref:`metadata_funcs` | :ref:`basic_model_interface`]

--- a/docs/source/bmi.spec.rst
+++ b/docs/source/bmi.spec.rst
@@ -74,12 +74,3 @@ grouped by functional category.
    :ref:`get_grid_face_nodes`      Get the face-node connectivity.
    :ref:`get_grid_nodes_per_face`  Get the number of nodes for each face.
    ==============================  =========================================
-
-..
-   Links
-
-.. _UDUNITS: https://www.unidata.ucar.edu/software/udunits/
-.. _The Units Database: https://docs.unidata.ucar.edu/udunits/current/#Database
-.. _time unit conventions: https://docs.unidata.ucar.edu/udunits/current/udunits2-accepted.xml
-.. _primitive types: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
-.. _wrapper classes: https://docs.oracle.com/javase/tutorial/java/data/numberclasses.html

--- a/docs/source/bmi.spec.rst
+++ b/docs/source/bmi.spec.rst
@@ -6,13 +6,17 @@ The Basic Model Interface
 The functions that comprise the Basic Model Interface
 can be grouped into categories:
 
-* :ref:`metadata_funcs`
-* :ref:`control_funcs`
-* :ref:`info_funcs`
-* :ref:`var_funcs`
-* :ref:`time_funcs`
-* :ref:`getter_setter_funcs`
-* :ref:`grid_funcs`
+.. toctree::
+   :maxdepth: 1
+
+   Metadata <bmi.metadata_funcs>
+   Control <bmi.control_funcs>
+   Info <bmi.info_funcs>
+   Variables <bmi.var_funcs>
+   Time <bmi.time_funcs>
+   Getters and setters <bmi.getter_setter>
+   Grid <bmi.grid_funcs>
+
 
 Table 3 lists the individual BMI functions
 along with a brief description.
@@ -70,15 +74,6 @@ grouped by functional category.
    :ref:`get_grid_face_nodes`      Get the face-node connectivity.
    :ref:`get_grid_nodes_per_face`  Get the number of nodes for each face.
    ==============================  =========================================
-
-.. include:: bmi.metadata_funcs.rst
-.. include:: bmi.control_funcs.rst
-.. include:: bmi.info_funcs.rst
-.. include:: bmi.var_funcs.rst
-.. include:: bmi.time_funcs.rst
-.. include:: bmi.getter_setter.rst
-.. include:: bmi.grid_funcs.rst
-
 
 ..
    Links

--- a/docs/source/bmi.time_funcs.rst
+++ b/docs/source/bmi.time_funcs.rst
@@ -25,8 +25,6 @@ The current model time.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`time_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_start_time:
 
@@ -47,8 +45,6 @@ The start time of the  model.
   from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`time_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_end_time:
@@ -72,8 +68,6 @@ The end time of the  model.
   from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`time_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_time_units:
@@ -104,8 +98,6 @@ It's recommended to use `time unit conventions`_ from Unidata's
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`time_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_time_step:
 
@@ -129,7 +121,5 @@ The time step is always expressed as a floating point value.
   from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`time_funcs` | :ref:`basic_model_interface`]
 
 .. include:: links.rst

--- a/docs/source/bmi.time_funcs.rst
+++ b/docs/source/bmi.time_funcs.rst
@@ -131,3 +131,5 @@ The time step is always expressed as a floating point value.
   (nonzero) is returned.
 
 [:ref:`time_funcs` | :ref:`basic_model_interface`]
+
+.. include:: links.rst

--- a/docs/source/bmi.var_funcs.rst
+++ b/docs/source/bmi.var_funcs.rst
@@ -39,8 +39,6 @@ A model can have one or more grids.
 * In C and Fortran, an integer status code indicating success (zero) or
   failure (nonzero) is returned.
 
-[:ref:`var_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_var_type:
 
@@ -67,8 +65,6 @@ while in Fortran, use `integer`, `real`, and `double precision`.
   (nonzero) is returned.
 * In Java, only `primitive types`_ (e.g., ``int``, ``double``), not
   `wrapper classes`_ (e.g., ``Integer``, ``Double``), are supported.
-
-[:ref:`var_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_var_units:
@@ -103,8 +99,6 @@ full description of valid unit names and a list of supported units.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`var_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_var_itemsize:
 
@@ -128,8 +122,6 @@ For example, if data for a variable are stored as 64-bit integers,
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-[:ref:`var_funcs` | :ref:`basic_model_interface`]
-
 
 .. _get_var_nbytes:
 
@@ -150,8 +142,6 @@ a variable; i.e., the number of items multiplied by the size of each item.
   amount of memory used by the variable is returned from the function.
 * In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-
-[:ref:`var_funcs` | :ref:`basic_model_interface`]
 
 
 .. _get_var_location:
@@ -180,7 +170,5 @@ element the variable is defined. Valid return values are:
   (nonzero) is returned.
 * If the given variable is a scalar (i.e., defined on a :ref:`scalar
   grid <unstructured_grids>`), the location from this function is ignored.
-
-[:ref:`var_funcs` | :ref:`basic_model_interface`]
 
 .. include:: links.rst

--- a/docs/source/bmi.var_funcs.rst
+++ b/docs/source/bmi.var_funcs.rst
@@ -183,7 +183,4 @@ element the variable is defined. Valid return values are:
 
 [:ref:`var_funcs` | :ref:`basic_model_interface`]
 
-
-.. Links
-
-.. _dtype: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
+.. include:: links.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,16 +76,7 @@ language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = [
-    "bmi.spec.rst",
-    "bmi.control_funcs.rst",
-    "bmi.info_funcs.rst",
-    "bmi.var_funcs.rst",
-    "bmi.time_funcs.rst",
-    "bmi.getter_setter.rst",
-    "bmi.grid_funcs.rst",
-    "bmi.metadata_funcs.rst",
-]
+exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,8 +81,6 @@ two documents may be particularly helpful when writing a BMI:
 
 A complete description of the functions that make up the BMI is given next.
 
-.. include:: bmi.spec.rst
-
 .. toctree::
    :caption: Getting Started
    :hidden:
@@ -96,6 +94,7 @@ A complete description of the functions that make up the BMI is given next.
    :hidden:
    :maxdepth: 2
 
+   BMI Spec <bmi.spec>
    model_grids
    BMI-based tools <csdms>
    glossary

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,17 +83,21 @@ A complete description of the functions that make up the BMI is given next.
 
 .. include:: bmi.spec.rst
 
-
-Additional Topics
-=================
-
 .. toctree::
+   :caption: Getting Started
+   :hidden:
    :maxdepth: 2
 
-   bmi.getting_started
+   How to <bmi.getting_started>
    bmi.best_practices
+
+.. toctree::
+   :caption: Reference
+   :hidden:
+   :maxdepth: 2
+
    model_grids
-   csdms
+   BMI-based tools <csdms>
    glossary
    references
 
@@ -101,31 +105,43 @@ BMI is an element of the `CSDMS Workbench`_,
 an integrated system of software tools, technologies, and standards
 for building and coupling models.
 
+..
+    Help
+    ----
 
-Help
-----
-
-Adding a BMI to a model can be a daunting task.
-If you'd like assistance,
-CSDMS can help.
-Depending on your need, we can provide advice or consulting services.
-Feel free to contact us through the `CSDMS Help Desk`_.
-
-
-Project Information
--------------------
+    Adding a BMI to a model can be a daunting task.
+    If you'd like assistance,
+    CSDMS can help.
+    Depending on your need, we can provide advice or consulting services.
+    Feel free to contact us through the `CSDMS Help Desk`_.
 
 .. toctree::
+   :caption: Contrubuting
+   :hidden:
+   :maxdepth: 1
+
+   contributing
+   Code of Conduct <conduct>
+
+.. toctree::
+   :caption: About
+   :hidden:
    :maxdepth: 1
 
    citation
-   contributing
-   conduct
    credits
    Governance <governance>
    council
    partners
 
+.. toctree::
+   :caption: Project Links
+   :hidden:
+   :maxdepth: 1
+
+   Help <https://github.com/csdms/help-desk>
+   GitHub <https://github.com/csdms/bmi>
+   Docs <https://bmi.readthedocs.io>
 
 .. Links:
 

--- a/docs/source/links.rst
+++ b/docs/source/links.rst
@@ -1,0 +1,9 @@
+..
+   Links
+
+.. _The Units Database: https://docs.unidata.ucar.edu/udunits/current/#Database
+.. _UDUNITS: https://www.unidata.ucar.edu/software/udunits/
+.. _dtype: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
+.. _primitive types: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
+.. _time unit conventions: https://docs.unidata.ucar.edu/udunits/current/udunits2-accepted.xml
+.. _wrapper classes: https://docs.oracle.com/javase/tutorial/java/data/numberclasses.html


### PR DESCRIPTION
This pull request breaks up the single, long bmi-spec page into separate, smaller pages.

I've removed the links that point to the top of each section because the *furo* theme has a back-to-top button on long pages. Similarly, I removed the links to the main page in the various bmi sections because the new layout has easier ways of getting there.