### PR TITLE
Use carets for headings instead of dots

### DIFF
--- a/docs/source/bmi.control_funcs.rst
+++ b/docs/source/bmi.control_funcs.rst
@@ -13,7 +13,7 @@ updating.
 .. _initialize:
 
 *initialize*
-............
+^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -48,7 +48,7 @@ formatted.
 .. _update:
 
 *update*
-........
+^^^^^^^^
 
 .. code-block:: java
 
@@ -77,7 +77,7 @@ function can just return without doing anything.
 .. _update_until:
 
 *update_until*
-..............
+^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -105,7 +105,7 @@ to reflect that the model was updated to the requested time.
 .. _finalize:
 
 *finalize*
-..........
+^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/bmi.getter_setter.rst
+++ b/docs/source/bmi.getter_setter.rst
@@ -19,7 +19,7 @@ state variable can be changed or check the new data for validity.
 .. _get_value:
 
 *get_value*
-...........
+^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -54,7 +54,7 @@ even if the model uses dimensional variables.
 .. _get_value_ptr:
 
 *get_value_ptr*
-...............
+^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -83,7 +83,7 @@ even if the model's state has changed.
 .. _get_value_at_indices:
 
 *get_value_at_indices*
-......................
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -109,7 +109,7 @@ Additionally,
 .. _set_value:
 
 *set_value*
-...........
+^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -144,7 +144,7 @@ even if the model uses dimensional variables.
 .. _set_value_at_indices:
 
 *set_value_at_indices*
-......................
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/bmi.grid_funcs.rst
+++ b/docs/source/bmi.grid_funcs.rst
@@ -26,7 +26,7 @@ However, all BMI grid functions must be implemented.
 .. _get_grid_type:
 
 *get_grid_type*
-...............
+^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -60,7 +60,7 @@ is given in the :ref:`model_grids` section.
 .. _get_grid_rank:
 
 *get_grid_rank*
-...............
+^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -90,7 +90,7 @@ of :ref:`get_grid_x`, :ref:`get_grid_y`, etc. are implemented.
 .. _get_grid_size:
 
 *get_grid_size*
-...............
+^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -120,7 +120,7 @@ for :ref:`unstructured <unstructured_grids>` and
 .. _get_grid_shape:
 
 *get_grid_shape*
-................
+^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -160,7 +160,7 @@ the cells.
 .. _get_grid_spacing:
 
 *get_grid_spacing*
-..................
+^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -191,7 +191,7 @@ the spacing between rows is followed by spacing between columns, ``[dy, dx]``.
 .. _get_grid_origin:
 
 *get_grid_origin*
-.................
+^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -223,7 +223,7 @@ the origin is given in the column dimension, followed by the row dimension,
 .. _get_grid_x:
 
 *get_grid_x*
-............
+^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -253,7 +253,7 @@ See :ref:`model_grids` for more information.
 .. _get_grid_y:
 
 *get_grid_y*
-............
+^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -283,7 +283,7 @@ See :ref:`model_grids` for more information.
 .. _get_grid_z:
 
 *get_grid_z*
-............
+^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -313,7 +313,7 @@ See :ref:`model_grids` for more information.
 .. _get_grid_node_count:
 
 *get_grid_node_count*
-.....................
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -337,7 +337,7 @@ Get the number of :term:`nodes <node>` in the grid.
 .. _get_grid_edge_count:
 
 *get_grid_edge_count*
-.....................
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -361,7 +361,7 @@ Get the number of :term:`edges <edge>` in the grid.
 .. _get_grid_face_count:
 
 *get_grid_face_count*
-.....................
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -385,7 +385,7 @@ Get the number of :term:`faces <face>` in the grid.
 .. _get_grid_edge_nodes:
 
 *get_grid_edge_nodes*
-.....................
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -413,7 +413,7 @@ node at edge head. The total length of the array is
 .. _get_grid_face_edges:
 
 *get_grid_face_edges*
-.....................
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -440,7 +440,7 @@ The length of the array returned is the sum of the values of
 .. _get_grid_face_nodes:
 
 *get_grid_face_nodes*
-.....................
+`````````````````````
 
 .. code-block:: java
 
@@ -472,7 +472,7 @@ the length of the array is the sum of the values of
 .. _get_grid_nodes_per_face:
 
 *get_grid_nodes_per_face*
-.........................
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/bmi.info_funcs.rst
+++ b/docs/source/bmi.info_funcs.rst
@@ -11,7 +11,7 @@ and provide to other models that have a BMI.
 .. _get_component_name:
 
 *get_component_name*
-....................
+^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -35,7 +35,7 @@ but it should be unique to prevent conflicts with other components.
 .. _get_input_item_count:
 
 *get_input_item_count*
-......................
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -59,7 +59,7 @@ Also the number of variables that can be set with :ref:`set_value`.
 .. _get_output_item_count:
 
 *get_output_item_count*
-.......................
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -83,7 +83,7 @@ Also the number of variables that can be retrieved with :ref:`get_value`.
 .. _get_input_var_names:
 
 *get_input_var_names*
-.....................
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -119,7 +119,7 @@ Standard Names do not have to be used within the model.
 .. _get_output_var_names:
 
 *get_output_var_names*
-......................
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/bmi.metadata_funcs.rst
+++ b/docs/source/bmi.metadata_funcs.rst
@@ -8,7 +8,7 @@ These functions supply metadata about a model and its BMI.
 .. _get_bmi_version:
 
 *get_bmi_version*
-.................
+^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/bmi.time_funcs.rst
+++ b/docs/source/bmi.time_funcs.rst
@@ -9,7 +9,7 @@ Model time is always expressed as a floating point value.
 .. _get_current_time:
 
 *get_current_time*
-..................
+^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -31,7 +31,7 @@ The current model time.
 .. _get_start_time:
 
 *get_start_time*
-................
+^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -54,7 +54,7 @@ The start time of the  model.
 .. _get_end_time:
 
 *get_end_time*
-................
+^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -79,7 +79,7 @@ The end time of the  model.
 .. _get_time_units:
 
 *get_time_units*
-................
+^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -110,7 +110,7 @@ It's recommended to use `time unit conventions`_ from Unidata's
 .. _get_time_step:
 
 *get_time_step*
-...............
+^^^^^^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/bmi.var_funcs.rst
+++ b/docs/source/bmi.var_funcs.rst
@@ -15,7 +15,7 @@ type or unit conversions can be applied when necessary.
 .. _get_var_grid:
 
 *get_var_grid*
-..............
+^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -45,7 +45,7 @@ A model can have one or more grids.
 .. _get_var_type:
 
 *get_var_type*
-..............
+^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -74,7 +74,7 @@ while in Fortran, use `integer`, `real`, and `double precision`.
 .. _get_var_units:
 
 *get_var_units*
-...............
+^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -109,7 +109,7 @@ full description of valid unit names and a list of supported units.
 .. _get_var_itemsize:
 
 *get_var_itemsize*
-..................
+^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -134,7 +134,7 @@ For example, if data for a variable are stored as 64-bit integers,
 .. _get_var_nbytes:
 
 *get_var_nbytes*
-................
+^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
@@ -157,7 +157,7 @@ a variable; i.e., the number of items multiplied by the size of each item.
 .. _get_var_location:
 
 *get_var_location*
-..................
+^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 

--- a/docs/source/governance.rst
+++ b/docs/source/governance.rst
@@ -58,7 +58,7 @@ foundations of Project governance are:
 * Institutional Neutrality
 
 Consensus-based decision making by the community
-................................................
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Normally, decisions on the Project will be made by consensus of all interested
 Contributors. The primary goal of this approach is to ensure that the people who
@@ -120,7 +120,7 @@ obstructive fashion to the detriment of the Project, then they can be ejected
 from the Project by consensus of the Steering Council--see below.
 
 Steering Council
-................
+^^^^^^^^^^^^^^^^
 
 The Project has a Steering Council (a.k.a. the BMI Council) that consists of
 Project Contributors and Users. The overall role of the Council is to ensure,
@@ -156,7 +156,7 @@ Project, then they will do so, but they will consider reaching this point to
 indicate a failure in their leadership.
 
 Council decision making
-.......................
+^^^^^^^^^^^^^^^^^^^^^^^
 
 If it becomes necessary for the Steering Council to produce a formal decision,
 then they will use a form of the `Apache Foundation voting process`_. This is a
@@ -173,7 +173,7 @@ In practice, we anticipate that for most Council decisions (e.g., voting in new
 members) a more informal process will suffice.
 
 Council membership
-..................
+^^^^^^^^^^^^^^^^^^
 
 A list of current Steering Council Members is maintained at the page `Steering
 Council`_.
@@ -215,7 +215,7 @@ and conflict resolution have failed. This requires the consensus of the
 remaining Members.
 
 Conflict of interest
-....................
+^^^^^^^^^^^^^^^^^^^^
 
 It is expected that Council Members will be employed at a range of universities,
 government agencies, companies, and non-profit organizations. Because of this,
@@ -233,7 +233,7 @@ particular issue may participate in Council discussions on that issue, but must
 recuse themselves from voting on the issue.
 
 Private communications of the Council
-.....................................
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To the maximum extent possible, Council discussions and activities will be
 public and done in collaboration and discussion with the Project Contributors
@@ -244,7 +244,7 @@ summarize those to the Community after eliding personal/private/sensitive
 information that should not be posted to the public internet.
 
 Subcommittees
-.............
+^^^^^^^^^^^^^
 
 The Council can create subcommittees that provide leadership and guidance for
 specific aspects of the Project. Like the Council as a whole, subcommittees


### PR DESCRIPTION
This pull request changes headings that used dots to use carets. The dots were causing problems for sphinx.