### PR TITLE
Convert remaining rst to myst

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -3,51 +3,50 @@
 If you use the Basic Model Interface for work/research
 presented in a publication, we ask that you please cite:
 
-```{eval-rst}
-.. tab-set::
+::::{tab-set}
 
-   .. tab-item:: APA
+:::{tab-item} APA
+Peckham, S.D., Hutton, E.W., and Norris, B., 2013. **A component-based
+approach to integrated modeling in the geosciences: The design of CSDMS**.
+*Computers & Geosciences*, 53, pp.3-12,
+https://doi.org/10.1016/j.cageo.2012.04.002.
 
-      Peckham, S.D., Hutton, E.W., and Norris, B., 2013. **A component-based
-      approach to integrated modeling in the geosciences: The design of CSDMS**.
-      *Computers & Geosciences*, 53, pp.3-12,
-      https://doi.org/10.1016/j.cageo.2012.04.002.
+Hutton, E.W.H., Piper, M.D., and Tucker, G.E., 2020. **The Basic Model
+Interface 2.0: A standard interface for coupling numerical models in the
+geosciences**. *Journal of Open Source Software*, 5(51), 2317,
+https://doi.org/10.21105/joss.02317.
+:::
 
-      Hutton, E.W.H., Piper, M.D., and Tucker, G.E., 2020. **The Basic Model
-      Interface 2.0: A standard interface for coupling numerical models in the
-      geosciences**. *Journal of Open Source Software*, 5(51), 2317,
-      https://doi.org/10.21105/joss.02317.
+:::{tab-item} BibTeX
+```bibtex
+@article{peckham2013component,
+    title={
+        A component-based approach to integrated modeling in the
+        geosciences: The design of CSDMS
+    },
+    author={Peckham, Scott D and Hutton, Eric WH and Norris, Boyana},
+    journal={Computers \& Geosciences},
+    volume={53},
+    pages={3--12},
+    year={2013},
+    publisher={Elsevier}
+}
 
-   .. tab-item:: BibTeX
-
-      .. code:: bibtex
-
-        @article{peckham2013component,
-            title={
-                A component-based approach to integrated modeling in the
-                geosciences: The design of CSDMS
-            },
-            author={Peckham, Scott D and Hutton, Eric WH and Norris, Boyana},
-            journal={Computers \& Geosciences},
-            volume={53},
-            pages={3--12},
-            year={2013},
-            publisher={Elsevier}
-        }
-
-        @article{hutton2020basic,
-            doi={10.21105/joss.02317},
-            url={https://doi.org/10.21105/joss.02317},
-            year={2020},
-            publisher={The Open Journal},
-            volume={5},
-            number={51},
-            pages={2317},
-            author={Eric W.H. Hutton and Mark D. Piper and Gregory E. Tucker},
-            title={
-                The Basic Model Interface 2.0: A standard interface for coupling
-                numerical models in the geosciences
-            },
-            journal={Journal of Open Source Software}
-        }
+@article{hutton2020basic,
+    doi={10.21105/joss.02317},
+    url={https://doi.org/10.21105/joss.02317},
+    year={2020},
+    publisher={The Open Journal},
+    volume={5},
+    number={51},
+    pages={2317},
+    author={Eric W.H. Hutton and Mark D. Piper and Gregory E. Tucker},
+    title={
+        The Basic Model Interface 2.0: A standard interface for coupling
+        numerical models in the geosciences
+    },
+    journal={Journal of Open Source Software}
+}
 ```
+:::
+::::

--- a/docs/source/bmi.control_funcs.md
+++ b/docs/source/bmi.control_funcs.md
@@ -13,24 +13,23 @@ updating.
 
 ## *initialize*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int initialize(in string config_file);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def initialize(self, config_file: str) -> None:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int initialize(in string config_file);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def initialize(self, config_file: str) -> None:
+```
+:::
+::::
 
 The `initialize` function accepts a string argument that gives the
 path to its {term}`configuration file`.
@@ -57,24 +56,23 @@ formatted.
 
 ## *update*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int update();
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def update(self) -> None:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int update();
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def update(self) -> None:
+```
+:::
+::::
 
 The `update` function advances the model by a single time step. This
 is the model's own internal time step (as returned by the BMI
@@ -96,24 +94,23 @@ function can just return without doing anything.
 
 ## *update_until*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int update_until(in double time);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def update_until(self, time: float) -> None:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int update_until(in double time);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def update_until(self, time: float) -> None:
+```
+:::
+::::
 
 The `update_until` function updates the model to a particular time,
 as provided by its *time* argument.
@@ -134,24 +131,23 @@ to reflect that the model was updated to the requested time.
 
 ## *finalize*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int finalize();
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def finalize(self) -> None:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int finalize();
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def finalize(self) -> None:
+```
+:::
+::::
 
 The `finalize` function should perform all tasks that take place
 after exiting the model's time loop.  This typically includes

--- a/docs/source/bmi.getter_setter.md
+++ b/docs/source/bmi.getter_setter.md
@@ -18,24 +18,23 @@ state variable can be changed or check the new data for validity.
 
 ## *get_value*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_value(in string name, in array<> dest);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_value(self, name: str, dest: NDArray[Any]) -> NDArray[Any]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_value(in string name, in array<> dest);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_value(self, name: str, dest: NDArray[Any]) -> NDArray[Any]:
+```
+:::
+::::
 
 The `get_value` function takes a variable name and copies values into a
 provided array parameter.
@@ -64,24 +63,23 @@ even if the model uses dimensional variables.
 
 ## *get_value_ptr*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_value_ptr(in string name, out array<> dest_ptr);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_value_ptr(self, name: str) -> NDArray[Any]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_value_ptr(in string name, out array<> dest_ptr);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_value_ptr(self, name: str) -> NDArray[Any]:
+```
+:::
+::::
 
 The `get_value_ptr` function takes a variable name and returns a reference
 to a variable.
@@ -103,26 +101,25 @@ even if the model's state has changed.
 
 ## *get_value_at_indices*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_value_at_indices(in string name, in array<> dest, in array<int, 1> inds);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_value_at_indices(
-             self, name: str, dest: NDArray[Any], inds: NDArray[np.int_]
-         ) -> NDArray[Any]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_value_at_indices(in string name, in array<> dest, in array<int, 1> inds);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_value_at_indices(
+    self, name: str, dest: NDArray[Any], inds: NDArray[np.int_]
+) -> NDArray[Any]:
+```
+:::
+::::
 
 Use the `get_value_at_indices` function to get a copy of a variable's values
 at the locations specified by the one-dimensional array indices
@@ -141,24 +138,23 @@ Additionally,
 
 ## *set_value*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int set_value(in string name, in array<> src);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def set_value(self, name: str, src: NDArray[Any]) -> None:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int set_value(in string name, in array<> src);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def set_value(self, name: str, src: NDArray[Any]) -> None:
+```
+:::
+::::
 
 The `set_value` function takes a variable name and an array of values,
 *src*,
@@ -186,26 +182,25 @@ even if the model uses dimensional variables.
 
 ## *set_value_at_indices*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int set_value_at_indices(in string name, in array<int, 1> inds, in array<> src);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def set_value_at_indices(
-             self, name: str, inds: NDArray[np.int_], src: NDArray[Any]
-         ) -> None:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int set_value_at_indices(in string name, in array<int, 1> inds, in array<> src);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def set_value_at_indices(
+    self, name: str, inds: NDArray[np.int_], src: NDArray[Any]
+) -> None:
+```
+:::
+::::
 
 Use the `set_value_at_indices` function to set a variable's values
 at the locations specified by the one-dimensional array indices
@@ -219,6 +214,5 @@ Additionally,
 - Both *src* and *inds* are flattened arrays.
 - The *inds* argument is always of type integer.
 
-```{eval-rst}
-.. include:: links.md
-```
+:::{include} links.md
+:::

--- a/docs/source/bmi.grid_funcs.md
+++ b/docs/source/bmi.grid_funcs.md
@@ -25,24 +25,23 @@ However, all BMI grid functions must be implemented.
 
 ## *get_grid_type*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_type(in int grid, out string type);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_type(self, grid: int) -> str:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_type(in int grid, out string type);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_type(self, grid: int) -> str:
+```
+:::
+::::
 
 Given a {term}`grid identifier`, get the type of that grid as a string.
 Valid grid types are:
@@ -69,24 +68,23 @@ is given in the {ref}`model-grids` section.
 
 ## *get_grid_rank*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_rank(in int grid, out int rank);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_rank(self, grid: int) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_rank(in int grid, out int rank);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_rank(self, grid: int) -> int:
+```
+:::
+::::
 
 Given a {term}`grid identifier`, get the {term}`rank` (the number of
 dimensions) of that grid as an integer.
@@ -109,24 +107,23 @@ of {ref}`get-grid-x`, {ref}`get-grid-y`, etc. are implemented.
 
 ## *get_grid_size*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_size(in int grid, out int size);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_size(self, grid: int) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_size(in int grid, out int size);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_size(self, grid: int) -> int:
+```
+:::
+::::
 
 Given a {term}`grid identifier`,
 get the total number of elements (or {term}`nodes <node>`)
@@ -149,24 +146,23 @@ for {ref}`unstructured <unstructured-grids>` and
 
 ## *get_grid_shape*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_shape(in int grid, in array<int, 1> shape);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_shape(self, grid: int, shape: NDArray[np.int_]) -> NDArray[np.int_]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_shape(in int grid, in array<int, 1> shape);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_shape(self, grid: int, shape: NDArray[np.int_]) -> NDArray[np.int_]:
+```
+:::
+::::
 
 Get the dimensions of the model grid.
 
@@ -199,26 +195,25 @@ the cells.
 
 ## *get_grid_spacing*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_spacing(in int grid, in array<double, 1> spacing);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_spacing(
-             self, grid: int, spacing: NDArray[np.float64]
-         ) -> NDArray[np.float64]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_spacing(in int grid, in array<double, 1> spacing);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_spacing(
+    self, grid: int, spacing: NDArray[np.float64]
+) -> NDArray[np.float64]:
+```
+:::
+::::
 
 Get the distance between the {term}`nodes <node>` of the model grid.
 
@@ -242,26 +237,25 @@ the spacing between rows is followed by spacing between columns, `[dy, dx]`.
 
 ## *get_grid_origin*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_origin(in int grid, in array<double, 1> origin);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_origin(
-             self, grid: int, origin: NDArray[np.float64]
-         ) -> NDArray[np.float64]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_origin(in int grid, in array<double, 1> origin);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_origin(
+    self, grid: int, origin: NDArray[np.float64]
+) -> NDArray[np.float64]:
+```
+:::
+::::
 
 Get the coordinates of the lower-left corner of the model grid.
 
@@ -286,24 +280,23 @@ the origin is given in the column dimension, followed by the row dimension,
 
 ## *get_grid_x*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_x(in int grid, in array<double, 1> x);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_x(self, grid: int, x: NDArray[np.float64]) -> NDArray[np.float64]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_x(in int grid, in array<double, 1> x);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_x(self, grid: int, x: NDArray[np.float64]) -> NDArray[np.float64]:
+```
+:::
+::::
 
 Get the locations of the grid {term}`nodes <node>` in the first
 coordinate direction.
@@ -326,24 +319,23 @@ See {ref}`model-grids` for more information.
 
 ## *get_grid_y*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_y(in int grid, in array<double, 1> y);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_y(self, grid: int, y: NDArray[np.float64]) -> NDArray[np.float64]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_y(in int grid, in array<double, 1> y);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_y(self, grid: int, y: NDArray[np.float64]) -> NDArray[np.float64]:
+```
+:::
+::::
 
 Get the locations of the grid {term}`nodes <node>` in the second
 coordinate direction.
@@ -366,24 +358,23 @@ See {ref}`model-grids` for more information.
 
 ## *get_grid_z*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_z(in int grid, in array<double, 1> z);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_z(self, grid: int, z: NDArray[np.float64]) -> NDArray[np.float64]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_z(in int grid, in array<double, 1> z);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_z(self, grid: int, z: NDArray[np.float64]) -> NDArray[np.float64]:
+```
+:::
+::::
 
 Get the locations of the grid {term}`nodes <node>` in the third
 coordinate direction.
@@ -406,24 +397,23 @@ See {ref}`model-grids` for more information.
 
 ## *get_grid_node_count*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_node_count(in int grid, out int count);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_node_count(self, grid: int) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_node_count(in int grid, out int count);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_node_count(self, grid: int) -> int:
+```
+:::
+::::
 
 Get the number of {term}`nodes <node>` in the grid.
 
@@ -440,24 +430,23 @@ Get the number of {term}`nodes <node>` in the grid.
 
 ## *get_grid_edge_count*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_edge_count(in int grid, out int count);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_edge_count(self, grid: int) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_edge_count(in int grid, out int count);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_edge_count(self, grid: int) -> int:
+```
+:::
+::::
 
 Get the number of {term}`edges <edge>` in the grid.
 
@@ -474,24 +463,23 @@ Get the number of {term}`edges <edge>` in the grid.
 
 ## *get_grid_face_count*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_face_count(in int grid, out int count);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_face_count(self, grid: int) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_face_count(in int grid, out int count);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_face_count(self, grid: int) -> int:
+```
+:::
+::::
 
 Get the number of {term}`faces <face>` in the grid.
 
@@ -508,26 +496,25 @@ Get the number of {term}`faces <face>` in the grid.
 
 ## *get_grid_edge_nodes*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_edge_nodes(in int grid, in array<int, 1> edge_nodes);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_edge_nodes(
-             self, grid: int, edge_nodes: NDArray[np.int_]
-         ) -> NDArray[np.int_]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_edge_nodes(in int grid, in array<int, 1> edge_nodes);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_edge_nodes(
+    self, grid: int, edge_nodes: NDArray[np.int_]
+) -> NDArray[np.int_]:
+```
+:::
+::::
 
 Get the edge-node connectivity.
 
@@ -548,26 +535,25 @@ node at edge head. The total length of the array is
 
 ## *get_grid_face_edges*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_face_edges(in int grid, in array<int, 1> face_edges);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_face_edges(
-             self, grid: int, face_edges: NDArray[np.int_]
-         ) -> NDArray[np.int_]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_face_edges(in int grid, in array<int, 1> face_edges);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_face_edges(
+    self, grid: int, face_edges: NDArray[np.int_]
+) -> NDArray[np.int_]:
+```
+:::
+::::
 
 Get the face-edge connectivity.
 
@@ -587,26 +573,25 @@ The length of the array returned is the sum of the values of
 
 ### *get_grid_face_nodes*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_face_nodes(in int grid, in array<int, 1> face_nodes);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_face_nodes(
-             self, grid: int, face_nodes: NDArray[np.int_]
-         ) -> NDArray[np.int_]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_face_nodes(in int grid, in array<int, 1> face_nodes);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_face_nodes(
+    self, grid: int, face_nodes: NDArray[np.int_]
+) -> NDArray[np.int_]:
+```
+:::
+::::
 
 Get the face-node connectivity.
 
@@ -631,26 +616,25 @@ the length of the array is the sum of the values of
 
 ## *get_grid_nodes_per_face*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_grid_nodes_per_face(in int grid, in array<int, 1> nodes_per_face);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_grid_nodes_per_face(
-             self, grid: int, nodes_per_face: NDArray[np.int_]
-         ) -> NDArray[np.int_]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_grid_nodes_per_face(in int grid, in array<int, 1> nodes_per_face);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_grid_nodes_per_face(
+    self, grid: int, nodes_per_face: NDArray[np.int_]
+) -> NDArray[np.int_]:
+```
+:::
+::::
 
 Get the number of nodes for each face.
 

--- a/docs/source/bmi.info_funcs.md
+++ b/docs/source/bmi.info_funcs.md
@@ -11,24 +11,23 @@ and provide to other models that have a BMI.
 
 ## *get_component_name*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_component_name(out string name);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_component_name(self) -> str:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_component_name(out string name);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_component_name(self) -> str:
+```
+:::
+::::
 
 This function supplies the name of the model component as a string.
 There are no restrictions on the name,
@@ -45,24 +44,23 @@ but it should be unique to prevent conflicts with other components.
 
 ## *get_input_item_count*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_input_item_count(out int count);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_input_item_count(self) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_input_item_count(out int count);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_input_item_count(self) -> int:
+```
+:::
+::::
 
 The number of variables the model can use from other models
 implementing a BMI.
@@ -79,24 +77,23 @@ Also the number of variables that can be set with {ref}`set-value`.
 
 ## *get_output_item_count*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_output_item_count(out int count);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_output_item_count(self) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_output_item_count(out int count);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_output_item_count(self) -> int:
+```
+:::
+::::
 
 The number of variables the model can provide other models
 implementing a BMI.
@@ -113,24 +110,22 @@ Also the number of variables that can be retrieved with {ref}`get-value`.
 
 ## *get_input_var_names*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_input_var_names(out array<string, 1> names);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_input_var_names(self) -> tuple[str, ...]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_input_var_names(out array<string, 1> names);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+```python
+def get_input_var_names(self) -> tuple[str, ...]:
+```
+:::
+::::
 
 Gets an array of names for the variables the model can use from other
 models implementing a BMI.
@@ -159,24 +154,23 @@ Standard Names do not have to be used within the model.
 
 ## *get_output_var_names*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_output_var_names(out array<string, 1> names);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_output_var_names(self) -> tuple[str, ...]:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_output_var_names(out array<string, 1> names);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_output_var_names(self) -> tuple[str, ...]:
+```
+:::
+::::
 
 Gets an array of names for the variables the model can provide to other
 models implementing a BMI.

--- a/docs/source/bmi.metadata_funcs.md
+++ b/docs/source/bmi.metadata_funcs.md
@@ -8,24 +8,23 @@ These functions supply metadata about a model and its BMI.
 
 ## *get_bmi_version*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_bmi_version(out string version);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_bmi_version(self) -> str:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_bmi_version(out string version);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_bmi_version(self) -> str:
+```
+:::
+::::
 
 :::{versionadded} 2.1
 :::

--- a/docs/source/bmi.time_funcs.md
+++ b/docs/source/bmi.time_funcs.md
@@ -9,24 +9,22 @@ Model time is always expressed as a floating point value.
 
 ## *get_current_time*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_current_time(out double time);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_current_time(self) -> float:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_current_time(out double time);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+```python
+def get_current_time(self) -> float:
+```
+:::
+::::
 
 The current model time.
 
@@ -41,24 +39,22 @@ The current model time.
 
 ## *get_start_time*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_start_time(out double time);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_start_time(self) -> float:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_start_time(out double time);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+```python
+def get_start_time(self) -> float:
+```
+:::
+::::
 
 The start time of the  model.
 
@@ -74,24 +70,22 @@ The start time of the  model.
 
 ## *get_end_time*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_end_time(out double time);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_end_time(self) -> float:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_end_time(out double time);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+``` python
+def get_end_time(self) -> float:
+```
+:::
+::::
 
 The end time of the  model.
 
@@ -109,24 +103,23 @@ The end time of the  model.
 
 ## *get_time_units*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_time_units(out string units);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_time_units(self) -> str:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_time_units(out string units);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_time_units(self) -> str:
+```
+:::
+::::
 
 Get the units of time as reported by the model's BMI (through
 {ref}`get-current-time`, {ref}`get-end-time`, etc.).
@@ -150,24 +143,22 @@ It's recommended to use [time unit conventions] from Unidata's
 
 ## *get_time_step*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_time_step(out double time_step);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_time_step(self) -> float:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_time_step(out double time_step);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+```python
+def get_time_step(self) -> float:
+```
+:::
+::::
 
 Get the time step used in the model.
 The time step is always expressed as a floating point value.
@@ -182,6 +173,5 @@ The time step is always expressed as a floating point value.
 - In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
 
-```{eval-rst}
-.. include:: links.md
-```
+:::{include} links.md
+:::

--- a/docs/source/bmi.var_funcs.md
+++ b/docs/source/bmi.var_funcs.md
@@ -14,25 +14,23 @@ type or unit conversions can be applied when necessary.
 
 ## *get_var_grid*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
+:::{tab-item} SIDL
+:sync: sidl
 
-      .. code-block:: java
-
-         int get_var_grid(in string name, out int grid);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_var_grid(self, name: str) -> int:
-
+```java
+int get_var_grid(in string name, out int grid);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+```python
+def get_var_grid(self, name: str) -> int:
+```
+:::
+::::
 
 Each input and output variable is defined on a grid.
 (Available grid types are listed in the {ref}`grid-funcs` section.)
@@ -55,24 +53,23 @@ A model can have one or more grids.
 
 ## *get_var_type*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_var_type(in string name, out string type);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_var_type(self, name: str) -> str:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_var_type(in string name, out string type);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_var_type(self, name: str) -> str:
+```
+:::
+::::
 
 The `get_var_type` function provides the data type of the
 variable as it's stored in memory by the model.
@@ -94,24 +91,23 @@ while in Fortran, use `integer`, `real`, and `double precision`.
 
 ## *get_var_units*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
+:::{tab-item} SIDL
+:sync: sidl
 
-      .. code-block:: java
-
-         int get_var_units(in string name, out string units);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_var_units(self, name: str) -> str:
+```java
+int get_var_units(in string name, out string units);
 ```
+:::
+:::{tab-item} Python
+:sync: python
+```python
+def get_var_units(self, name: str) -> str:
+```
+:::
+::::
 
 Get the units of the given variable.
 Standard unit names, in lower case, should be used,
@@ -139,24 +135,23 @@ full description of valid unit names and a list of supported units.
 
 ## *get_var_itemsize*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_var_itemsize(in string name, out int size);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_var_itemsize(self, name: str) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_var_itemsize(in string name, out int size);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_var_itemsize(self, name: str) -> int:
+```
+:::
+::::
 
 The `get_var_itemsize` function provides the size, in bytes,
 of a single element of the variable.
@@ -174,24 +169,23 @@ For example, if data for a variable are stored as 64-bit integers,
 
 ## *get_var_nbytes*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_var_nbytes(in string name, out int nbytes);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_var_nbytes(self, name: str) -> int:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_var_nbytes(in string name, out int nbytes);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_var_nbytes(self, name: str) -> int:
+```
+:::
+::::
 
 The `get_var_nbytes` function provides the total amount of memory used to store
 a variable; i.e., the number of items multiplied by the size of each item.
@@ -207,24 +201,23 @@ a variable; i.e., the number of items multiplied by the size of each item.
 
 ## *get_var_location*
 
-```{eval-rst}
-.. tab-set::
-   :sync-group: lang
+::::{tab-set}
+:sync-group: lang
 
-   .. tab-item:: SIDL
-      :sync: sidl
-
-      .. code-block:: java
-
-         int get_var_location(in string name, out string location);
-
-   .. tab-item:: Python
-      :sync: python
-
-      .. code-block:: python
-
-         def get_var_location(self, name: str) -> str:
+:::{tab-item} SIDL
+:sync: sidl
+```java
+int get_var_location(in string name, out string location);
 ```
+:::
+
+:::{tab-item} Python
+:sync: python
+```python
+def get_var_location(self, name: str) -> str:
+```
+:::
+::::
 
 The `get_var_location` function,
 given a variable name, returns a string that indicates on what grid
@@ -243,6 +236,5 @@ element the variable is defined. Valid return values are:
 - If the given variable is a scalar (i.e., defined on a {ref}`scalar
   grid <unstructured-grids>`), the location from this function is ignored.
 
-```{eval-rst}
-.. include:: links.md
-```
+:::{include} links.md
+:::


### PR DESCRIPTION
This pull request convert the remaining *ReStructuredText* to *MyST*. This is all of the `{eval-rst}` blocks, which were mainly tables and tabs.