### PR TITLE
Automate language mappings

### DIFF
--- a/docs/source/bmi.control_funcs.md
+++ b/docs/source/bmi.control_funcs.md
@@ -18,22 +18,28 @@ updating.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int initialize(in string config_file);
+```{map-bmi-function} initialize
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def initialize(self, config_file: str) -> None:
+```{map-bmi-function} initialize
+:language: python
 ```
 :::
 
 :::{tab-item} c
 :sync: c
-```c
-int initialize(void *self, char *config_file);
+```{map-bmi-function} initialize
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} initialize
+:language: c++
 ```
 :::
 ::::
@@ -68,22 +74,28 @@ formatted.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int update();
+```{map-bmi-function} update
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def update(self) -> None:
+```{map-bmi-function} update
+:language: python
 ```
 :::
 
 :::{tab-item} c
 :sync: c
-```c
-int update(void *self);
+```{map-bmi-function} update
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} update
+:language: c++
 ```
 :::
 ::::
@@ -113,21 +125,27 @@ function can just return without doing anything.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int update_until(in double time);
+```{map-bmi-function} update_until
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def update_until(self, time: float) -> None:
+```{map-bmi-function} update_until
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int update_until(void *self, double then);
+```{map-bmi-function} update_until
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} update_until
+:language: c++
 ```
 :::
 ::::
@@ -156,22 +174,28 @@ to reflect that the model was updated to the requested time.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int finalize();
+```{map-bmi-function} finalize
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def finalize(self) -> None:
+```{map-bmi-function} finalize
+:language: python
 ```
 :::
 
 :::{tab-item} c
 :sync: c
-```c
-int finalize(void *self);
+```{map-bmi-function} finalize
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} finalize
+:language: c++
 ```
 :::
 ::::

--- a/docs/source/bmi.getter_setter.md
+++ b/docs/source/bmi.getter_setter.md
@@ -23,21 +23,27 @@ state variable can be changed or check the new data for validity.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_value(in string name, in array<> dest);
+```{map-bmi-function} get_value
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_value(self, name: str, dest: NDArray[Any]) -> NDArray[Any]:
+```{map-bmi-function} get_value
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_value(void *self, const char *name, void *dest);
+```{map-bmi-function} get_value
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_value
+:language: c++
 ```
 :::
 ::::
@@ -74,21 +80,27 @@ even if the model uses dimensional variables.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_value_ptr(in string name, out array<> dest_ptr);
+```{map-bmi-function} get_value_ptr
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_value_ptr(self, name: str) -> NDArray[Any]:
+```{map-bmi-function} get_value_ptr
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_value_ptr(void *self, const char *name, void **dest_ptr);
+```{map-bmi-function} get_value_ptr
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_value_ptr
+:language: c++
 ```
 :::
 ::::
@@ -118,25 +130,27 @@ even if the model's state has changed.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_value_at_indices(in string name, in array<> dest, in array<int, 1> inds);
+```{map-bmi-function} get_value_at_indices
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_value_at_indices(
-    self, name: str, dest: NDArray[Any], inds: NDArray[np.int_]
-) -> NDArray[Any]:
+```{map-bmi-function} get_value_at_indices
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_value_at_indices(
-    void *self, const char *name, void *dest, int *inds, int count
-);
+```{map-bmi-function} get_value_at_indices
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_value_at_indices
+:language: c++
 ```
 :::
 ::::
@@ -163,21 +177,27 @@ Additionally,
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int set_value(in string name, in array<> src);
+```{map-bmi-function} set_value
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def set_value(self, name: str, src: NDArray[Any]) -> None:
+```{map-bmi-function} set_value
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int set_value(void *self, const char *name, void *src);
+```{map-bmi-function} set_value
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} set_value
+:language: c++
 ```
 :::
 ::::
@@ -213,25 +233,27 @@ even if the model uses dimensional variables.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int set_value_at_indices(in string name, in array<int, 1> inds, in array<> src);
+```{map-bmi-function} set_value_at_indices
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def set_value_at_indices(
-    self, name: str, inds: NDArray[np.int_], src: NDArray[Any]
-) -> None:
+```{map-bmi-function} set_value_at_indices
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int set_value_at_indices(
-    void *self, const char *name, int *inds, int count, void *src
-);
+```{map-bmi-function} set_value_at_indices
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} set_value_at_indices
+:language: c++
 ```
 :::
 ::::

--- a/docs/source/bmi.grid_funcs.md
+++ b/docs/source/bmi.grid_funcs.md
@@ -30,21 +30,27 @@ However, all BMI grid functions must be implemented.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_type(in int grid, out string type);
+```{map-bmi-function} get_grid_type
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_type(self, grid: int) -> str:
+```{map-bmi-function} get_grid_type
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_type(void *self, int grid, char *type);
+```{map-bmi-function} get_grid_type
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_type
+:language: c++
 ```
 :::
 ::::
@@ -79,21 +85,27 @@ is given in the {ref}`model-grids` section.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_rank(in int grid, out int rank);
+```{map-bmi-function} get_grid_rank
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_rank(self, grid: int) -> int:
+```{map-bmi-function} get_grid_rank
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_rank(void *self, int grid, int *rank);
+```{map-bmi-function} get_grid_rank
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_rank
+:language: c++
 ```
 :::
 ::::
@@ -124,21 +136,27 @@ of {ref}`get-grid-x`, {ref}`get-grid-y`, etc. are implemented.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_size(in int grid, out int size);
+```{map-bmi-function} get_grid_size
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_size(self, grid: int) -> int:
+```{map-bmi-function} get_grid_size
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_size(void *self, int grid, int *size);
+```{map-bmi-function} get_grid_size
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_size
+:language: c++
 ```
 :::
 ::::
@@ -169,21 +187,27 @@ for {ref}`unstructured <unstructured-grids>` and
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_shape(in int grid, in array<int, 1> shape);
+```{map-bmi-function} get_grid_shape
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_shape(self, grid: int, shape: NDArray[np.int_]) -> NDArray[np.int_]:
+```{map-bmi-function} get_grid_shape
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_shape(void *self, int grid, int *shape);
+```{map-bmi-function} get_grid_shape
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_shape
+:language: c++
 ```
 :::
 ::::
@@ -224,23 +248,27 @@ the cells.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_spacing(in int grid, in array<double, 1> spacing);
+```{map-bmi-function} get_grid_spacing
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_spacing(
-    self, grid: int, spacing: NDArray[np.float64]
-) -> NDArray[np.float64]:
+```{map-bmi-function} get_grid_spacing
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_spacing(void *self, int grid, double *spacing);
+```{map-bmi-function} get_grid_spacing
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_spacing
+:language: c++
 ```
 :::
 ::::
@@ -272,23 +300,27 @@ the spacing between rows is followed by spacing between columns, `[dy, dx]`.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_origin(in int grid, in array<double, 1> origin);
+```{map-bmi-function} get_grid_origin
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_origin(
-    self, grid: int, origin: NDArray[np.float64]
-) -> NDArray[np.float64]:
+```{map-bmi-function} get_grid_origin
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_origin(void *self, int grid, double *origin);
+```{map-bmi-function} get_grid_origin
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_origin
+:language: c++
 ```
 :::
 ::::
@@ -321,21 +353,27 @@ the origin is given in the column dimension, followed by the row dimension,
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_x(in int grid, in array<double, 1> x);
+```{map-bmi-function} get_grid_x
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_x(self, grid: int, x: NDArray[np.float64]) -> NDArray[np.float64]:
+```{map-bmi-function} get_grid_x
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_x(void *self, int grid, double *x);
+```{map-bmi-function} get_grid_x
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_x
+:language: c++
 ```
 :::
 ::::
@@ -366,21 +404,27 @@ See {ref}`model-grids` for more information.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_y(in int grid, in array<double, 1> y);
+```{map-bmi-function} get_grid_y
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_y(self, grid: int, y: NDArray[np.float64]) -> NDArray[np.float64]:
+```{map-bmi-function} get_grid_y
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_y(void *self, int grid, double *y);
+```{map-bmi-function} get_grid_y
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_y
+:language: c++
 ```
 :::
 ::::
@@ -411,21 +455,27 @@ See {ref}`model-grids` for more information.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_z(in int grid, in array<double, 1> z);
+```{map-bmi-function} get_grid_z
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_z(self, grid: int, z: NDArray[np.float64]) -> NDArray[np.float64]:
+```{map-bmi-function} get_grid_z
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_z(void *self, int grid, double *z);
+```{map-bmi-function} get_grid_z
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_z
+:language: c++
 ```
 :::
 ::::
@@ -456,21 +506,27 @@ See {ref}`model-grids` for more information.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_node_count(in int grid, out int count);
+```{map-bmi-function} get_grid_node_count
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_node_count(self, grid: int) -> int:
+```{map-bmi-function} get_grid_node_count
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_node_count(void *self, int grid, int *count);
+```{map-bmi-function} get_grid_node_count
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_node_count
+:language: c++
 ```
 :::
 ::::
@@ -495,21 +551,27 @@ Get the number of {term}`nodes <node>` in the grid.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_edge_count(in int grid, out int count);
+```{map-bmi-function} get_grid_edge_count
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_edge_count(self, grid: int) -> int:
+```{map-bmi-function} get_grid_edge_count
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_edge_count(void *self, int grid, int *count);
+```{map-bmi-function} get_grid_edge_count
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_edge_count
+:language: c++
 ```
 :::
 ::::
@@ -534,21 +596,27 @@ Get the number of {term}`edges <edge>` in the grid.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_face_count(in int grid, out int count);
+```{map-bmi-function} get_grid_face_count
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_face_count(self, grid: int) -> int:
+```{map-bmi-function} get_grid_face_count
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_face_count(void *self, int grid, int *count);
+```{map-bmi-function} get_grid_face_count
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_face_count
+:language: c++
 ```
 :::
 ::::
@@ -573,23 +641,27 @@ Get the number of {term}`faces <face>` in the grid.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_edge_nodes(in int grid, in array<int, 1> edge_nodes);
+```{map-bmi-function} get_grid_edge_nodes
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_edge_nodes(
-    self, grid: int, edge_nodes: NDArray[np.int_]
-) -> NDArray[np.int_]:
+```{map-bmi-function} get_grid_edge_nodes
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_edge_nodes(void *self, int grid, int *edge_nodes);
+```{map-bmi-function} get_grid_edge_nodes
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_edge_nodes
+:language: c++
 ```
 :::
 ::::
@@ -618,23 +690,27 @@ node at edge head. The total length of the array is
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_face_edges(in int grid, in array<int, 1> face_edges);
+```{map-bmi-function} get_grid_face_edges
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_face_edges(
-    self, grid: int, face_edges: NDArray[np.int_]
-) -> NDArray[np.int_]:
+```{map-bmi-function} get_grid_face_edges
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_face_edges(void *self, int grid, int *face_edges);
+```{map-bmi-function} get_grid_face_edges
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_face_edges
+:language: c++
 ```
 :::
 ::::
@@ -662,23 +738,27 @@ The length of the array returned is the sum of the values of
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_face_nodes(in int grid, in array<int, 1> face_nodes);
+```{map-bmi-function} get_grid_face_nodes
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_face_nodes(
-    self, grid: int, face_nodes: NDArray[np.int_]
-) -> NDArray[np.int_]:
+```{map-bmi-function} get_grid_face_nodes
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_face_nodes(void *self, int grid, int *face_nodes);
+```{map-bmi-function} get_grid_face_nodes
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_face_nodes
+:language: c++
 ```
 :::
 ::::
@@ -711,23 +791,27 @@ the length of the array is the sum of the values of
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_grid_nodes_per_face(in int grid, in array<int, 1> nodes_per_face);
+```{map-bmi-function} get_grid_nodes_per_face
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_grid_nodes_per_face(
-    self, grid: int, nodes_per_face: NDArray[np.int_]
-) -> NDArray[np.int_]:
+```{map-bmi-function} get_grid_nodes_per_face
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_grid_nodes_per_face(void *self, int grid, int *nodes_per_face);
+```{map-bmi-function} get_grid_nodes_per_face
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_grid_nodes_per_face
+:language: c++
 ```
 :::
 ::::

--- a/docs/source/bmi.info_funcs.md
+++ b/docs/source/bmi.info_funcs.md
@@ -16,21 +16,27 @@ and provide to other models that have a BMI.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_component_name(out string name);
+```{map-bmi-function} get_component_name
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_component_name(self) -> str:
+```{map-bmi-function} get_component_name
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_component_name(void *self, char *name);
+```{map-bmi-function} get_component_name
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_component_name
+:language: c++
 ```
 :::
 ::::
@@ -55,21 +61,27 @@ but it should be unique to prevent conflicts with other components.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_input_item_count(out int count);
+```{map-bmi-function} get_input_item_count
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_input_item_count(self) -> int:
+```{map-bmi-function} get_input_item_count
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_input_item_count(void *self, int *count);
+```{map-bmi-function} get_input_item_count
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_input_item_count
+:language: c++
 ```
 :::
 ::::
@@ -94,21 +106,27 @@ Also the number of variables that can be set with {ref}`set-value`.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_output_item_count(out int count);
+```{map-bmi-function} get_output_item_count
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_output_item_count(self) -> int:
+```{map-bmi-function} get_output_item_count
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_output_item_count(void *self, int *count);
+```{map-bmi-function} get_output_item_count
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_output_item_count
+:language: c++
 ```
 :::
 ::::
@@ -133,20 +151,26 @@ Also the number of variables that can be retrieved with {ref}`get-value`.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_input_var_names(out array<string, 1> names);
+```{map-bmi-function} get_input_var_names
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-```python
-def get_input_var_names(self) -> tuple[str, ...]:
+```{map-bmi-function} get_input_var_names
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_input_var_names(void *self, char **names);
+```{map-bmi-function} get_input_var_names
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_input_var_names
+:language: c++
 ```
 :::
 ::::
@@ -183,21 +207,27 @@ Standard Names do not have to be used within the model.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_output_var_names(out array<string, 1> names);
+```{map-bmi-function} get_output_var_names
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_output_var_names(self) -> tuple[str, ...]:
+```{map-bmi-function} get_output_var_names
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_output_var_names(void *self, char **names);
+```{map-bmi-function} get_output_var_names
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_output_var_names
+:language: c++
 ```
 :::
 ::::

--- a/docs/source/bmi.metadata_funcs.md
+++ b/docs/source/bmi.metadata_funcs.md
@@ -13,21 +13,27 @@ These functions supply metadata about a model and its BMI.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_bmi_version(out string version);
+```{map-bmi-function} get_bmi_version
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_bmi_version(self) -> str:
+```{map-bmi-function} get_bmi_version
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_bmi_version(void *self, char *version);
+```{map-bmi-function} get_bmi_version
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_bmi_version
+:language: c++
 ```
 :::
 ::::

--- a/docs/source/bmi.time_funcs.md
+++ b/docs/source/bmi.time_funcs.md
@@ -14,20 +14,26 @@ Model time is always expressed as a floating point value.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_current_time(out double time);
+```{map-bmi-function} get_current_time
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-```python
-def get_current_time(self) -> float:
+```{map-bmi-function} get_current_time
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_current_time(void *self, double *time);
+```{map-bmi-function} get_current_time
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_current_time
+:language: c++
 ```
 :::
 ::::
@@ -50,20 +56,26 @@ The current model time.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_start_time(out double time);
+```{map-bmi-function} get_start_time
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-```python
-def get_start_time(self) -> float:
+```{map-bmi-function} get_start_time
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_start_time(void *self, double *time);
+```{map-bmi-function} get_start_time
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_start_time
+:language: c++
 ```
 :::
 ::::
@@ -87,20 +99,26 @@ The start time of the  model.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_end_time(out double time);
+```{map-bmi-function} get_end_time
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-``` python
-def get_end_time(self) -> float:
+```{map-bmi-function} get_end_time
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_end_time(void *self, double *time);
+```{map-bmi-function} get_end_time
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_end_time
+:language: c++
 ```
 :::
 ::::
@@ -126,21 +144,27 @@ The end time of the  model.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_time_units(out string units);
+```{map-bmi-function} get_time_units
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_time_units(self) -> str:
+```{map-bmi-function} get_time_units
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_time_units(void *self, char *units);
+```{map-bmi-function} get_time_units
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_time_units
+:language: c++
 ```
 :::
 ::::
@@ -172,20 +196,26 @@ It's recommended to use [time unit conventions] from Unidata's
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_time_step(out double time_step);
+```{map-bmi-function} get_time_step
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-```python
-def get_time_step(self) -> float:
+```{map-bmi-function} get_time_step
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_time_step(void *self, double *time_step);
+```{map-bmi-function} get_time_step
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_time_step
+:language: c++
 ```
 :::
 ::::

--- a/docs/source/bmi.var_funcs.md
+++ b/docs/source/bmi.var_funcs.md
@@ -20,20 +20,26 @@ type or unit conversions can be applied when necessary.
 :::{tab-item} SIDL
 :sync: sidl
 
-```java
-int get_var_grid(in string name, out int grid);
+```{map-bmi-function} get_var_grid
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-```python
-def get_var_grid(self, name: str) -> int:
+```{map-bmi-function} get_var_grid
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_var_grid(void *self, const char *name, int *grid);
+```{map-bmi-function} get_var_grid
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_var_grid
+:language: c++
 ```
 :::
 ::::
@@ -64,21 +70,27 @@ A model can have one or more grids.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_var_type(in string name, out string type);
+```{map-bmi-function} get_var_type
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_var_type(self, name: str) -> str:
+```{map-bmi-function} get_var_type
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_var_type(void *self, const char *name, char *type);
+```{map-bmi-function} get_var_type
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_var_type
+:language: c++
 ```
 :::
 ::::
@@ -108,21 +120,26 @@ while in Fortran, use `integer`, `real`, and `double precision`.
 
 :::{tab-item} SIDL
 :sync: sidl
-
-```java
-int get_var_units(in string name, out string units);
+```{map-bmi-function} get_var_units
+:language: sidl
 ```
 :::
 :::{tab-item} Python
 :sync: python
-```python
-def get_var_units(self, name: str) -> str:
+```{map-bmi-function} get_var_units
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_var_units(void *self, const char *name, char *units);
+```{map-bmi-function} get_var_units
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_var_units
+:language: c++
 ```
 :::
 ::::
@@ -158,21 +175,27 @@ full description of valid unit names and a list of supported units.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_var_itemsize(in string name, out int size);
+```{map-bmi-function} get_var_itemsize
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_var_itemsize(self, name: str) -> int:
+```{map-bmi-function} get_var_itemsize
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_var_itemsize(void *self, const char *name, int *size);
+```{map-bmi-function} get_var_itemsize
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_var_itemsize
+:language: c++
 ```
 :::
 ::::
@@ -198,21 +221,27 @@ For example, if data for a variable are stored as 64-bit integers,
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_var_nbytes(in string name, out int nbytes);
+```{map-bmi-function} get_var_nbytes
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_var_nbytes(self, name: str) -> int:
+```{map-bmi-function} get_var_nbytes
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_var_nbytes(void *self, const char *name, int *nbytes);
+```{map-bmi-function} get_var_nbytes
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_var_nbytes
+:language: c++
 ```
 :::
 ::::
@@ -236,21 +265,27 @@ a variable; i.e., the number of items multiplied by the size of each item.
 
 :::{tab-item} SIDL
 :sync: sidl
-```java
-int get_var_location(in string name, out string location);
+```{map-bmi-function} get_var_location
+:language: sidl
 ```
 :::
 
 :::{tab-item} Python
 :sync: python
-```python
-def get_var_location(self, name: str) -> str:
+```{map-bmi-function} get_var_location
+:language: python
 ```
 :::
 :::{tab-item} c
 :sync: c
-```c
-int get_var_location(void *self, const char *name, char *location);
+```{map-bmi-function} get_var_location
+:language: c
+```
+:::
+:::{tab-item} c++
+:sync: c++
+```{map-bmi-function} get_var_location
+:language: c++
 ```
 :::
 ::::


### PR DESCRIPTION
This pull request adds a custom directive, `map-bmi-function`, that inserts a language mapping of a BMI function to sphinx documentation. Using MyST, it looks something like,

````
```{map-bmi-function} get_value
:language: c
```
````