### PR TITLE
Add map-bmi-function directive

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
 furo
 myst-parser
+pygments
 sphinx
 sphinx_design
+git+https://github.com/mcflugen/bmi-map.git

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,9 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import find_lexer_class_by_name
+
 extensions = [
     "myst_parser",
     "sphinx.ext.intersphinx",
@@ -60,3 +66,31 @@ html_static_path = ["_static"]
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 myst_enable_extensions = ["colon_fence", "deflist"]
+
+
+class MapBmiFunction(Directive):
+    """Insert a highlighted BMI function mapped to a language."""
+
+    required_arguments = 1
+    option_spec = {"language": str}
+
+    has_content = False
+
+    def run(self):
+        from bmi_map.bmi_map import map_bmi_function
+
+        function_name = self.arguments[0]
+        language = self.options.get("language")
+
+        content = map_bmi_function(function_name, language)
+
+        lexer = find_lexer_class_by_name(language if language != "sidl" else "java")()
+        highlighted_code = highlight(content, lexer, HtmlFormatter())
+
+        node = nodes.raw("", highlighted_code, format="html")
+
+        return [node]
+
+
+def setup(app):
+    app.add_directive("map-bmi-function", MapBmiFunction)


### PR DESCRIPTION
This pull request adds a new *sphinx* directive, `map-bmi-function`, that will insert a language mapping of a BMI function into our rendered *sphinx* documentation.

It has one required argument, the function to be mapped, and one option, the language for the mapping. For example (using *MyST*),
````
```{map-bmi-fuction} get_value
:language: c
```
````
will insert the `get_value` definition as expressed in *C*.