### PR TITLE
Require v0.1.0 of bmi-map

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ myst-parser
 pygments
 sphinx
 sphinx_design
-git+https://github.com/mcflugen/bmi-map.git
+git+https://github.com/mcflugen/bmi-map.git@v0.1.0


### PR DESCRIPTION
There was a bug in *bmi-map* that produced incorrect *SIDL* parameter lists, but I fixed that with https://github.com/mcflugen/bmi-map/pull/20. *bmi-map* *v0.1.0* includes that fix so I've added that to the requirements list for the BMI docs.