### PR TITLE
Grid identifiers don't have to start at zero

### DIFF
--- a/docs/source/bmi.var_funcs.md
+++ b/docs/source/bmi.var_funcs.md
@@ -55,7 +55,6 @@ A model can have one or more grids.
 
 **Implementation notes**
 
-- Grid identifiers start at 0.
 - In C++, Java, and Python, the *grid* argument is omitted and the grid
   identifier is returned from the function.
 - In C and Fortran, an integer status code indicating success (zero) or


### PR DESCRIPTION
I've removed some wording in the description of `get_var_grid` that said grid ids start at 0. In fact, they can be any integer at all.