### PR TITLE
Add none location to get_var_location

### DIFF
--- a/docs/source/bmi.var_funcs.md
+++ b/docs/source/bmi.var_funcs.md
@@ -297,6 +297,10 @@ element the variable is defined. Valid return values are:
 - `node`
 - `edge`
 - `face`
+- `none`
+
+A value of `none` indicates the variable is not attached to a grid and
+that `get_var_grid` will not be implemented for this variable.
 
 **Implementation notes**
 
@@ -304,8 +308,6 @@ element the variable is defined. Valid return values are:
   is returned from the function.
 - In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-- If the given variable is a scalar (i.e., defined on a {ref}`scalar
-  grid <unstructured-grids>`), the location from this function is ignored.
 
 :::{include} links.md
 :::

--- a/docs/source/bmi.var_funcs.md
+++ b/docs/source/bmi.var_funcs.md
@@ -297,10 +297,18 @@ element the variable is defined. Valid return values are:
 - `node`
 - `edge`
 - `face`
-- `none`
+- `none` (see note)
 
 A value of `none` indicates the variable is not attached to a grid and
 that `get_var_grid` will not be implemented for this variable.
+
+:::{attention}
+
+The return value `"none"` from `get_var_location` is not part of the current
+BMI specification, but has seen informal use to indicate variables not tied
+to a grid location. This usage may be formally supported in a future version
+of the specification.
+:::
 
 **Implementation notes**
 


### PR DESCRIPTION
If a variable does not have a grid, then its location should be reported as `"none"`. This means that `get_var_grid` for that variable will not be implemented or, if it is, the return value will be meaningless.