### PR TITLE
Remove text referencing scalar grid types

### DIFF
--- a/docs/source/bmi.best_practices.md
+++ b/docs/source/bmi.best_practices.md
@@ -38,10 +38,10 @@ here are some tips to help when writing a BMI for a model.
   coupling models written in different languages. It's the developer's
   responsibility to ensure that array information is
   flattened/redimensionalized in the correct order.
-- Recall that models can have multiple grids. This can be particularly
-  useful for defining {term}`exchange items <exchange item>` that
-  don't vary over the model domain; e.g., a diffusivity -- just define
-  the variable on a separate {ref}`scalar grid <unstructured-grids>`.
+- Recall that model variables do not have to be attached to a grid.
+  This can be useful for defining {term}`exchange items <exchange item>`
+  that don't vary over the model domain.
+- Models can have multiple grids.
 - Avoid using global variables, if possible. This isn't strictly a BMI
   requirement, but if a model only uses local variables, its BMI will
   be self-contained. This may allow multiple instances of the model to

--- a/docs/source/bmi.grid_funcs.md
+++ b/docs/source/bmi.grid_funcs.md
@@ -10,12 +10,6 @@ returned from the {ref}`get-var-grid` function.
 This identifier is a required input to the functions listed below.
 
 A model can have multiple grids.
-For example,
-consider modeling the diffusion of temperature over a flat plate.
-One grid could be a uniform rectilinear grid on which
-temperature is defined.
-A second grid could be a scalar,
-on which a constant thermal diffusivity is defined.
 
 Not all grid functions are used by each type of grid.
 However, all BMI grid functions must be implemented.

--- a/docs/source/bmi.grid_funcs.md
+++ b/docs/source/bmi.grid_funcs.md
@@ -4,7 +4,7 @@
 
 The functions in this section describe {ref}`model grids <model-grids>`.
 In the BMI,
-every {term}`exchange item` is defined on a grid,
+if an {term}`exchange item` is defined on a grid,
 and is referenced by a {term}`grid identifier`
 returned from the {ref}`get-var-grid` function.
 This identifier is a required input to the functions listed below.

--- a/docs/source/bmi.grid_funcs.md
+++ b/docs/source/bmi.grid_funcs.md
@@ -58,7 +58,6 @@ However, all BMI grid functions must be implemented.
 Given a {term}`grid identifier`, get the type of that grid as a string.
 Valid grid types are:
 
-- `scalar`
 - `points`
 - `vector`
 - `unstructured`

--- a/docs/source/bmi.var_funcs.md
+++ b/docs/source/bmi.var_funcs.md
@@ -304,8 +304,6 @@ element the variable is defined. Valid return values are:
   is returned from the function.
 - In C and Fortran, an integer status code indicating success (zero) or failure
   (nonzero) is returned.
-- If the given variable is a scalar (i.e., defined on a {ref}`scalar
-  grid <unstructured-grids>`), the location from this function is ignored.
 
 :::{include} links.md
 :::

--- a/docs/source/model_grids.md
+++ b/docs/source/model_grids.md
@@ -131,8 +131,8 @@ Structured quadrilateral grids use the following BMI functions:
 ```
 
 This category includes the *unstructured* type,
-as well as the special cases
-*scalar*, *points*, and *vector*.
+as well as the special case of a grid of *points* (i.e.
+unconnected nodes).
 This is the most general grid type.
 It can be used for any type of grid.
 This grid type must be used if the grid consists of cells


### PR DESCRIPTION
What was described as a "scalar" grid type in the docs was really a variable without a grid. The correct way to deal with this case is to not assign a grid to these variables (i.e. their `get_var_location` should return `"none"`). None of the `get_grid_` functions need to be implemented for these variables.