### PR TITLE
Update the list of BMI Council members

### DIFF
--- a/docs/source/council.md
+++ b/docs/source/council.md
@@ -17,4 +17,4 @@ The current members of the BMI Council are:
 
 Former members:
 
-- Niels Drost (eScience Center)
+- Niels Drost (eScience Center) (2022-2025)

--- a/docs/source/council.md
+++ b/docs/source/council.md
@@ -3,7 +3,6 @@
 The current members of the BMI Council are:
 
 - Ryan Cabell (NCAR)
-- Niels Drost (eScience Center)
 - Joe Hughes (USGS)
 - Rolf Hut (TU Delft)
 - Eric Hutton (CSDMS)
@@ -13,4 +12,9 @@ The current members of the BMI Council are:
 - Fred Ogden (NOAA)
 - Scott Peckham (University of Colorado and NOAA)
 - Mark Piper (CSDMS)
+- Bart Schilperoort (eScience Center)
 - Greg Tucker (University of Colorado and CSDMS)
+
+Former members:
+
+- Niels Drost (eScience Center)


### PR DESCRIPTION
This PR updates the current list of BMI Council members, rotating @BSchilperoort on and @nielsdrost off.
