### PR TITLE
List R mappings and example

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,9 +21,11 @@
 - Scott Peckham
 - Mark Piper
 - Carlos Erazo Ramirez
+- Bart Schilperoort
 - Mike Taves
 - Greg Tucker
 - Ashani Vaidya
+- Stefan Verhoeven
 - Martijn Visser
 - Ben van Werkhoven
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and are [acknowledged](./AUTHORS.rst).
 
 The table below lists community-contributed
 language specifications and examples
-for Javascript and Julia.
+for two languages, Javascript and Julia.
 
 | Language   | Specification | Example implementation |
 | ---------- | ------------- | ---------------------- |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ are listed in the table below.
 | Fortran  | [bmi-fortran] | [bmi-example-fortran]  |
 | Java     | [bmi-java]    | [bmi-example-java]     |
 | Python   | [bmi-python]  | [bmi-example-python]   |
+| R        | [bmi-r]       | [bmi-example-r]        |
 
 Detailed instructions for building the specifications and examples
 are given at each link above.
@@ -74,13 +75,12 @@ and are [acknowledged](./AUTHORS.rst).
 
 The table below lists community-contributed
 language specifications and examples
-for Javascript, Julia, and R.
+for Javascript and Julia.
 
 | Language   | Specification | Example implementation |
 | ---------- | ------------- | ---------------------- |
 | Javascript | [bmi-js]      | [bmi-example-js]       |
 | Julia      | [bmi-julia]   | [bmi-example-julia]    |
-| R          | [bmi-r]       | [bmi-example-r]        |
 
 The default branch of this repository
 reflects the current state of development for the BMI.

--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ and are [acknowledged](./AUTHORS.rst).
 
 The table below lists community-contributed
 language specifications and examples
-for two languages, Javascript and Julia.
+for Javascript, Julia, and R.
 
 | Language   | Specification | Example implementation |
 | ---------- | ------------- | ---------------------- |
 | Javascript | [bmi-js]      | [bmi-example-js]       |
 | Julia      | [bmi-julia]   | [bmi-example-julia]    |
+| R          | [bmi-r]       | [bmi-example-r]        |
 
 The default branch of this repository
 reflects the current state of development for the BMI.
@@ -109,11 +110,13 @@ is supported by the National Science Foundation.*
 [bmi-example-js]: https://github.com/uihilab/bmi-example-js
 [bmi-example-julia]: https://github.com/csdms/bmi-example-julia
 [bmi-example-python]: https://github.com/csdms/bmi-example-python
+[bmi-example-r]: https://github.com/csdms/bmi-example-r
 [bmi-fortran]: https://github.com/csdms/bmi-fortran
 [bmi-java]: https://github.com/csdms/bmi-java
 [bmi-js]: https://github.com/uihilab/bmi-js
 [bmi-julia]: https://github.com/Deltares/BasicModelInterface.jl
 [bmi-python]: https://github.com/csdms/bmi-python
+[bmi-r]: https://github.com/csdms/bmi-r
 [community surface dynamics modeling system]: https://csdms.colorado.edu
 [csdms workbench]: https://csdms.colorado.edu/wiki/Workbench
 [documentation]: https://bmi.readthedocs.io

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -52,11 +52,12 @@ in which the BMI is implemented.
 | Fortran  | [bmi.f90]     | [bmi-fortran]  | [bmi-example-fortran]  |
 | Java     | [bmi.java]    | [bmi-java]     | [bmi-example-java]     |
 | Python   | [bmi.py]      | [bmi-python]   | [bmi-example-python]   |
+| R        | [bmi.R]       | [bmi-r]      | [bmi-example-r]          |
 :::
 
 BMI is a community standard.
 Table 2 lists community-contributed language specifications and examples
-for Javascript, Julia, and R.
+for Javascript and Julia.
 
 :::{table} **Table 2:** Community-contributed BMI languages.
 :align: center
@@ -66,7 +67,6 @@ for Javascript, Julia, and R.
 | ---------- | ------------- | ------------ | -------------------- |
 | Javascript | [bmi.js]      | [bmi-js]     | [bmi-example-js]     |
 | Julia      | [bmi.jl]      | [bmi-julia]  | [bmi-example-julia]  |
-| R          | [bmi.R]       | [bmi-r]      | [bmi-example-r]      |
 :::
 
 Along with the examples,

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -56,7 +56,7 @@ in which the BMI is implemented.
 
 BMI is a community standard.
 Table 2 lists community-contributed language specifications and examples
-for two languages, Javascript and Julia.
+for Javascript, Julia, and R.
 
 :::{table} **Table 2:** Community-contributed BMI languages.
 :align: center
@@ -66,6 +66,7 @@ for two languages, Javascript and Julia.
 | ---------- | ------------- | ------------ | -------------------- |
 | Javascript | [bmi.js]      | [bmi-js]     | [bmi-example-js]     |
 | Julia      | [bmi.jl]      | [bmi-julia]  | [bmi-example-julia]  |
+| R          | [bmi.R]       | [bmi-r]      | [bmi-example-r]      |
 :::
 
 Along with the examples,
@@ -155,11 +156,13 @@ Docs <https://bmi.readthedocs.io>
 [bmi-example-js]: https://github.com/uihilab/bmi-example-js
 [bmi-example-julia]: https://github.com/csdms/bmi-example-julia
 [bmi-example-python]: https://github.com/csdms/bmi-example-python
+[bmi-example-r]: https://github.com/csdms/bmi-example-r
 [bmi-fortran]: https://github.com/csdms/bmi-fortran
 [bmi-java]: https://github.com/csdms/bmi-java
 [bmi-js]: https://github.com/uihilab/bmi-js
 [bmi-julia]: https://github.com/Deltares/BasicModelInterface.jl
 [bmi-python]: https://github.com/csdms/bmi-python
+[bmi-r]: https://github.com/csdms/bmi-r
 [bmi.f90]: https://github.com/csdms/bmi-fortran/blob/master/bmi.f90
 [bmi.h]: https://github.com/csdms/bmi-c/blob/master/bmi.h
 [bmi.hxx]: https://github.com/csdms/bmi-cxx/blob/master/bmi.hxx
@@ -167,6 +170,7 @@ Docs <https://bmi.readthedocs.io>
 [bmi.jl]: https://github.com/Deltares/BasicModelInterface.jl/blob/master/src/BasicModelInterface.jl
 [bmi.js]: https://github.com/uihilab/BMI-JS/blob/main/bmijs/bmi.js
 [bmi.py]: https://github.com/csdms/bmi-python/blob/master/src/bmipy/bmi.py
+[bmi.R]: https://github.com/csdms/bmi-r/blob/main/R/bmi.R
 [community surface dynamics modeling system]: https://csdms.colorado.edu
 [csdms help desk]: https://github.com/csdms/help-desk
 [csdms workbench]: https://csdms.colorado.edu/wiki/Workbench

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -57,7 +57,7 @@ in which the BMI is implemented.
 
 BMI is a community standard.
 Table 2 lists community-contributed language specifications and examples
-for Javascript and Julia.
+for two languages, Javascript and Julia.
 
 :::{table} **Table 2:** Community-contributed BMI languages.
 :align: center


### PR DESCRIPTION
This PR lists Basic Model Interface R mappings and an example in the documentation. The mappings are based on those created by @sverhoeven in [eWaterCycle/bmi-r](https://github.com/eWaterCycle/bmi-r). In writing the current mappings and example, I received help from @sverhoeven and @BSchilperoort.

Because the mappings haven't been field-tested, I chose to list them under the "community contributed" table in the documentation. My hope is that by making this code public, any flaws will be exposed, and we can then return to improve it.

This fixes #17.