### PR TITLE
Update Council membership

### DIFF
--- a/docs/source/council.md
+++ b/docs/source/council.md
@@ -3,11 +3,13 @@
 The current members of the BMI Council are:
 
 - Ryan Cabell (NCAR)
+- Nels Frazier (Lynker)
 - Joe Hughes (INTERA)
 - Rolf Hut (TU Delft)
 - Eric Hutton (CSDMS)
 - Bert Jagers (Deltares)
 - Allen Lee (CoMSES Net)
+- Phil Miller (Lynker)
 - Fred Ogden (NOAA)
 - Scott Peckham (University of Colorado and NOAA)
 - Mark Piper (CSDMS)

--- a/docs/source/council.md
+++ b/docs/source/council.md
@@ -8,7 +8,6 @@ The current members of the BMI Council are:
 - Eric Hutton (CSDMS)
 - Bert Jagers (Deltares)
 - Allen Lee (CoMSES Net)
-- Rich McDonald (USGS)
 - Fred Ogden (NOAA)
 - Scott Peckham (University of Colorado and NOAA)
 - Mark Piper (CSDMS)
@@ -18,3 +17,4 @@ The current members of the BMI Council are:
 Former members:
 
 - Niels Drost (eScience Center) (2022-2025)
+- Rich McDonald (USGS) (2022-2025)

--- a/docs/source/council.md
+++ b/docs/source/council.md
@@ -3,7 +3,7 @@
 The current members of the BMI Council are:
 
 - Ryan Cabell (NCAR)
-- Joe Hughes (USGS)
+- Joe Hughes (INTERA)
 - Rolf Hut (TU Delft)
 - Eric Hutton (CSDMS)
 - Bert Jagers (Deltares)


### PR DESCRIPTION
This PR proposes changes to the BMI Council membership:

* Rotate Nels and Phil on
* Rotate Rich off (thank you, Rich!)
* Update Joe's affiliation

Phil and Nels have done a mountain of work in proposing and developing a new BMI extension framework. 

From the [Council membership section](https://bmi.csdms.io/en/stable/governance.html#council-membership) of our governance document, all we need is consensus, which we appeared to have in the last Council meeting. If anyone objects, discuss it here; otherwise, we can merge this change in a week or so.