### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ See the links above for details.
 While CSDMS currently supports the languages listed above,
 a BMI specification can be written for any language.
 BMI is a community-driven standard;
-[contributions](CONTRIBUTING.rst)
-that follow the [contributor code of conduct](./CODE-OF-CONDUCT.rst)
+[contributions](CONTRIBUTING.md)
+that follow the [contributor code of conduct](./CODE-OF-CONDUCT.md)
 are welcomed,
-and are [acknowledged](./AUTHORS.rst).
+and are [acknowledged](./AUTHORS.md).
 
 The table below lists community-contributed
 language specifications and examples


### PR DESCRIPTION
Links in the README pointed to the previous versions of AUTHORS, CONTRIBUTING, and CODE-OF-CONDUCT in *rst* format. I changed them to point to the updated versions in *md* format.